### PR TITLE
Adding indexes to generator for mongoid

### DIFF
--- a/lib/generators/rolify/role/templates/role-mongoid.rb
+++ b/lib/generators/rolify/role/templates/role-mongoid.rb
@@ -5,4 +5,13 @@ class <%= role_cname.camelize %>
   belongs_to :resource, :polymorphic => true
   
   field :name, :type => String
+  index :name, unique: true
+  index(
+    [
+      [:name, Mongo::ASCENDING],
+      [:resource_type, Mongo::ASCENDING],
+      [:resource_id, Mongo::ASCENDING]
+    ],
+    unique: true
+  )
 end

--- a/spec/generators/rolify/role/role_generator_spec.rb
+++ b/spec/generators/rolify/role/role_generator_spec.rb
@@ -174,6 +174,16 @@ describe Rolify::Generators::RoleGenerator do
       it { should contain "class Role\n" }
       it { should contain "has_and_belongs_to_many :users\n" }
       it { should contain "belongs_to :resource, :polymorphic => true" }
+      it { should contain "field :name, :type => String" }
+      it { should contain "index :name, unique: true" }
+      it { should contain "  index(\n"
+                          "    [\n"
+                          "      [:name, Mongo::ASCENDING],\n"
+                          "      [:resource_type, Mongo::ASCENDING],\n"
+                          "      [:resource_id, Mongo::ASCENDING]\n"
+                          "    ],\n"
+                          "    unique: true\n"
+                          "  )\n" }
     end
     
     describe 'app/models/user.rb' do


### PR DESCRIPTION
I found that the active record generator generates migrations with indexes like that:

```
add_index(:roles, :name)
add_index(:roles, [ :name, :resource_type, :resource_id ])
add_index(:users_roles, [ :user_id, :role_id ])
```

Those are not added when using Mongoid, so I added them, at least the first two. I wasn't sure how to add the last one. Maybe someone can jump in?
