### PR TITLE
Extending Mongoid::Document before other rails plugins access models

### DIFF
--- a/lib/rolify/railtie.rb
+++ b/lib/rolify/railtie.rb
@@ -8,7 +8,7 @@ module Rolify
         ActiveRecord::Base.send :extend, Rolify
       end
       
-      config.after_initialize do
+      config.before_initialize do
         ::Mongoid::Document.module_eval do
           def self.included(base)
             base.extend Rolify


### PR DESCRIPTION
Loading rolify before initializing other plugin code. Fixes i.e. a problem with ActiveAdmin when using mongoid.

Closing issue #57
