### PR TITLE
Reject nil items from resources_find return

### DIFF
--- a/lib/rolify/adapters/mongoid/resource_adapter.rb
+++ b/lib/rolify/adapters/mongoid/resource_adapter.rb
@@ -13,7 +13,7 @@ module Rolify
             resources << role.resource
           end
         end
-        resources.uniq.reject{|r| r.nil?}
+        resources.uniq.reject {|r| r.nil? }
       end
 
       def in(resources, user, role_names)


### PR DESCRIPTION
I encountered a strange condition where the result from `resources_find` would be [nil]. This simply rejects nil items from the array to fix the issue.
