### PR TITLE
Replace 1.8-incompatible Hash#select with a Hash#reject

### DIFF
--- a/lib/rolify.rb
+++ b/lib/rolify.rb
@@ -19,7 +19,7 @@ module Rolify
 
     rolify_options = { :class_name => options[:role_cname].camelize }
     rolify_options.merge!({ :join_table => "#{self.to_s.tableize}_#{options[:role_cname].tableize}" }) if Rolify.orm == "active_record"
-    rolify_options.merge!(options.select{ |k,v| [:before_add, :after_add, :before_remove, :after_remove].include? k.to_sym }) if Rolify.orm == "active_record"
+    rolify_options.merge!(options.reject{ |k,v| ![:before_add, :after_add, :before_remove, :after_remove].include? k.to_sym }) if Rolify.orm == "active_record"
 
     has_and_belongs_to_many :roles, rolify_options
 


### PR DESCRIPTION
Replaced 1.8-incompatible Hash#select with a Hash#reject to make sure the gem still works on 1.8 (for those who still use ActiveRecord on the most popular version of Ruby).
