### PR TITLE
Test cases for User#add_role method when useing Mongoid adapter and the resource is resourcifed and rolifed in the same time

### DIFF
--- a/spec/rolify/resourcifed_and_rolifed_spec.rb
+++ b/spec/rolify/resourcifed_and_rolifed_spec.rb
@@ -1,0 +1,26 @@
+if ENV['ADAPTER'] == 'mongoid'
+  require "spec_helper"
+
+  describe "#add_role" do
+    before(:all) do
+      reset_defaults
+      Role.delete_all
+      SUser.delete_all
+    end
+    let!(:user) { user = SUser.new login: 'Samer'; user.save; user }
+    context "when adapter is Mongoid" do
+      context "and the resource is resourcifed and rolifed in the same time" do
+        it "should add the role to the user" do
+          expect{
+            user.add_role :admin
+          }.to change{user.roles.count}.by(1)
+        end
+        it "should create a role to the roles collection" do
+          expect {
+            user.add_role :moderator
+          }.to change { Role.count }.by(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/adapters/mongoid.rb
+++ b/spec/support/adapters/mongoid.rb
@@ -22,6 +22,15 @@ class User
   field :login, :type => String
 end
 
+# Resourcifed and rolifed at the sametime
+class SUser
+  include Mongoid::Document
+  resourcify
+  rolify
+
+  field :login, :type => String
+end
+
 class Role
   include Mongoid::Document
   has_and_belongs_to_many :users


### PR DESCRIPTION
Basically the problem happens when the method `user.roles` is called, and that happens when we try to add a new role, more specifically in `lib/rolify/adapters/mongoid/role_adapter.rb`

```
def add(relation, role)
   relation.roles << role
end
```

When you add `resourcify` and `rolify` for the same model basically you are doing something like

```
class User
  include Mongoid::Document

  has_many :roles
  has_and_belongs_to_many :roles

  field :name, type: String
end
```

And that seems to cause a great deal of confusion for our friend Mongoid. I think that Mongoid is defining a new method but with a wrong name which probably caused an infinite recursion and that's resulted in a `SystemStackError: stack level too deep`.

I'm not sure but maybe this is a Mongoid bug, but for sure we can do something to work around it.

I hope this was useful.
#102
