### PR TITLE
remove_role / revoke produces invalid SQL error if role_name argument is a symbol

### DIFF
--- a/lib/rolify/role.rb
+++ b/lib/rolify/role.rb
@@ -52,7 +52,7 @@ module Rolify
     end
 
     def remove_role(role_name, resource = nil)
-      self.class.adapter.remove(self, role_name, resource)
+      self.class.adapter.remove(self, role_name.to_s, resource)
     end
     
     alias_method :revoke, :remove_role


### PR DESCRIPTION
If you do a `user_object.add_role :admin` it succeeds but if you do `user_object.remove_role :admin` it'll produce something below:

```
ActiveRecord::StatementInvalid: SQLite3::SQLException: no such column: roles.admin: SELECT "roles".* FROM "roles" INNER JOIN "users_roles" ON "roles"."id" = "users_roles"."role_id" WHERE "users_roles"."user_id" = 10 AND "roles"."name" = "roles"."admin"
```

Attached code is the simple fix that performs `role_name.to_s` to ensure a symbol can be accepted. **Not sure on the resource argument. It may require tweaking as well. See `def add_role` for reference.**
