### PR TITLE
Replace deprecated find_or_create_by.

### DIFF
--- a/lib/rolify/adapters/active_record/role_adapter.rb
+++ b/lib/rolify/adapters/active_record/role_adapter.rb
@@ -9,7 +9,7 @@ module Rolify
       end
 
       def find_or_create_by(role_name, resource_type = nil, resource_id = nil)
-        role_class.where(name: role_name, resource_type: resource_type, resource_id: resource_id).first_or_create
+        role_class.where(:name => role_name, :resource_type => resource_type, :resource_id => resource_id).first_or_create
       end
 
       def add(relation, role)


### PR DESCRIPTION
Rails 4 deprecates the find_or_create_by helpers. This change replaces
the deprecated method while maintaining backwards compatibility with
Rails 3.
