### PR TITLE
Update README.md to reflect the current generator name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In <b>Rails 3</b>, add this to your Gemfile and run the +bundle+ command.
 First, create your Role model and migration file using this generator:
 
 ```
-  rails g rolify Role User
+  rails g rolify:role Role User
 ```
 
 Role and User classes are the default. You can specify any Role class name you want. This is completly a new file so any name can do the job.


### PR DESCRIPTION
The current version in Rubygems uses the `rolify:role` generator name, but the README still indicates the older generator name. This commit fixes that.
