### PR TITLE
Update example of "with any role" method in README.md to avoid ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ Forum.with_role(:admin)
 # => [ list of Forum instances that has role "admin" binded to it ] 
 Forum.with_role(:admin, current_user)
 # => [ list of Forum instances that has role "admin" binded to it and belongs to current_user roles ]
-Forum.with_any_role(:user, :admin)
-# => [ list of Forum instances that has role "admin" or "user" binded to it ]
+
+User.with_any_role(:user, :admin)
+# => [ list of User instances that has role "admin" or "user" binded to it ]
 
 Forum.find_roles
 # => [ list of roles that binded to any Forum instance or to the Forum class ]


### PR DESCRIPTION
README.md is ambiguous by stating that `Forum.with_any_role(:user, :admin)` when Forum is a `resourcify` model.

I've got `undefined method 'with_any_role'` while trying to do `Forum.with_any_role(:user, :admin)`. Not sure if this is a bug. Close this PR if it is.

Thanks.
