### PR TITLE
Support has_many :through instead of just only has_and_belongs_to_many

### DIFF
--- a/lib/rolify.rb
+++ b/lib/rolify.rb
@@ -19,15 +19,24 @@ module Rolify
     self.role_cname = options[:role_cname]
     self.role_table_name = self.role_cname.tableize.gsub(/\//, "_")
 
-    default_join_table = "#{self.to_s.tableize.gsub(/\//, "_")}_#{self.role_table_name}"
-    options.reverse_merge!({:role_join_table_name => default_join_table})
-    self.role_join_table_name = options[:role_join_table_name]
-
     rolify_options = { :class_name => options[:role_cname].camelize }
-    rolify_options.merge!({ :join_table => self.role_join_table_name }) if Rolify.orm == "active_record"
     rolify_options.merge!(options.reject{ |k,v| ![ :before_add, :after_add, :before_remove, :after_remove ].include? k.to_sym })
 
-    has_and_belongs_to_many :roles, rolify_options
+    # Option to support has_many :through
+    has_many_through_table = options.delete(:has_many_through)
+    if has_many_through_table
+      self.role_join_table_name = has_many_through_table
+      rolify_options[:through] = self.role_join_table_name
+
+      has_many :roles, rolify_options
+    else
+      default_join_table = "#{self.to_s.tableize.gsub(/\//, "_")}_#{self.role_table_name}"
+      options.reverse_merge!({:role_join_table_name => default_join_table})
+      self.role_join_table_name = options[:role_join_table_name]
+      rolify_options.merge!({ :join_table => self.role_join_table_name }) if Rolify.orm == "active_record"
+
+      has_and_belongs_to_many :roles, rolify_options
+    end
 
     self.adapter = Rolify::Adapter::Base.create("role_adapter", self.role_cname, self.name)
     load_dynamic_methods if Rolify.dynamic_shortcuts


### PR DESCRIPTION
`has_and_belongs_to_many` works well for most of use-cases, but it's annoying if we want to:
- Use a custom join table instead of having to follow the rule `"#{self.to_s.tableize.gsub(/\//, "_")}_#{self.role_table_name}"`
- Have more fields in the join table, e.g: `created_at` and `updated_at`

For the above reasons, I added one more option called `has_many_through` to allow developer can use a customized join table by `has_many :through` association.
