### PR TITLE
Add check for roles table before initializing use_dynamic_shortcuts

### DIFF
--- a/lib/generators/rolify/templates/initializer.rb
+++ b/lib/generators/rolify/templates/initializer.rb
@@ -4,5 +4,7 @@ Rolify.configure<%= "(\"#{class_name.camelize.to_s}\")" if class_name != "Role" 
   
   # Dynamic shortcuts for User class (user.is_admin? like methods). Default is: false
   # Enable this feature _after_ running rake db:migrate as it relies on the roles table
-  # config.use_dynamic_shortcuts
+  #if ActiveRecord::Base.connection.table_exists? 'roles'
+  #  config.use_dynamic_shortcuts
+  #end
 end


### PR DESCRIPTION
This check is necessary to avoid "roles" does not exist errors during a new deploy.
