### PR TITLE
Fix has_any_role? to work with unsaved records.

### DIFF
--- a/lib/rolify/role.rb
+++ b/lib/rolify/role.rb
@@ -44,7 +44,11 @@ module Rolify
     end
 
     def has_any_role?(*args)
-      self.class.adapter.where(self.roles, *args).size > 0
+      if new_record?
+        args.any? { |r| self.has_role?(r) }
+      else
+        self.class.adapter.where(self.roles, *args).size > 0
+      end
     end
     
     def only_has_role?(role_name, resource = nil)

--- a/spec/rolify/shared_examples/shared_examples_for_roles.rb
+++ b/spec/rolify/shared_examples/shared_examples_for_roles.rb
@@ -93,6 +93,7 @@ shared_examples_for Rolify::Role do
     
     it { should have_role :admin }
     it { should have_role :moderator, Forum.first }    
+    it { subject.has_any_role?(:admin).should be_true }
   end  
   
   context "on the Class level ", :scope => :mixed do  


### PR DESCRIPTION
`has_any_role?` doesn't work with unsaved records, while `has_role?` does. Here's the current behaviour:

```
>> u = User.new
=> #<User id: nil, [...]>
>> u.add_role :administrator
=> #<Role id: 417269330, name: "administrator", [...]>
>> u.has_role? :administrator
=> true
>> u.has_any_role? :administrator
=> false
```

This patch fixes the issue so that in the above example `has_any_role?` would return true.
