### PR TITLE
Added method remove_role_from_user_for_resource. remove_role method doesn't work correctly.

### DIFF
--- a/lib/rolify/adapters/active_record/role_adapter.rb
+++ b/lib/rolify/adapters/active_record/role_adapter.rb
@@ -30,6 +30,17 @@ module Rolify
         roles
       end
 
+      def remove_from_resource(relation, role_name, resource)
+        cond = { :name => role_name }
+        cond[:resource_type] = (resource.is_a?(Class) ? resource.to_s : resource.class.name) if resource
+        cond[:resource_id] = resource.id if resource && !resource.is_a?(Class)
+        roles = relation.roles.where(cond)
+        if roles
+          relation.roles.delete(roles)
+        end
+        roles
+      end
+
       def exists?(relation, column)
         relation.where("#{column} IS NOT NULL")
       end

--- a/lib/rolify/role.rb
+++ b/lib/rolify/role.rb
@@ -54,6 +54,10 @@ module Rolify
     def remove_role(role_name, resource = nil)
       self.class.adapter.remove(self, role_name.to_s, resource)
     end
+
+    def remove_role_from_user_for_resource(role_name, resource)
+      self.class.adapter.remove_from_resource(self, role_name.to_s, resource)
+    end
     
     alias_method :revoke, :remove_role
     deprecate :has_no_role, :remove_role


### PR DESCRIPTION
When using the "remove_role" method to remove a role from a user for a particular resource, it removes the role itself from the roles table, thus, removing the role from all users who have that role instead of only the user we called "remove_role" on. A "remove_role_from_user_for_resource" method was added that fixes this problem.
