### PR TITLE
Add select(:id) to active record 'in' query to avoid MySQL errors in Rails 4.0.2

### DIFF
--- a/lib/rolify/adapters/active_record/resource_adapter.rb
+++ b/lib/rolify/adapters/active_record/resource_adapter.rb
@@ -12,7 +12,7 @@ module Rolify
       end
 
       def in(relation, user, role_names)
-        roles = user.roles.where(:name => role_names)
+        roles = user.roles.where(:name => role_names).select(:id)
         relation.where("#{quote(role_class.table_name)}.#{role_class.primary_key} IN (?) AND ((resource_id = #{quote(relation.table_name)}.#{relation.primary_key}) OR (resource_id IS NULL))", roles)
       end
 


### PR DESCRIPTION
When using the latest version of Rails, we saw errors like:

``` sql
Mysql2::Error: Operand should contain 1 column(s): 
SELECT `catalogs`.* FROM `catalogs` 
INNER JOIN `roles` ON `roles`.resource_type = 'Catalog' AND
  (`roles`.resource_id IS NULL OR `roles`.resource_id = `catalogs`.id) 
WHERE (`roles`.name IN ('read_only') AND `roles`.resource_type = 'Catalog') AND 
  (`roles`.id IN (
    SELECT `roles`.* FROM `roles` 
    INNER JOIN `users_roles` ON `roles`.`id` = `users_roles`.`role_id` 
    WHERE `users_roles`.`user_id` = 1 AND `roles`.`name` = 'read_only'
  ) AND ((resource_id = `catalogs`.id) OR (resource_id IS NULL)))
```

This is corrected by changing `SELECT `roles`.* FROM `roles`` to `SELECT `roles`.id FROM `roles`` in the subquery.
