### PR TITLE
Significant speed improvement when removing roles.

### DIFF
--- a/lib/rolify/adapters/active_record/role_adapter.rb
+++ b/lib/rolify/adapters/active_record/role_adapter.rb
@@ -24,7 +24,7 @@ module Rolify
         if roles
           relation.roles.delete(roles)
           roles.each do |role|
-            role.destroy if role.send(ActiveSupport::Inflector.demodulize(user_class).tableize.to_sym).empty?
+            role.destroy if role.send(ActiveSupport::Inflector.demodulize(user_class).tableize.to_sym).limit(1).empty?
           end
         end
         roles


### PR DESCRIPTION
This avoids running a big SQL query which could potentially return a large number of rows. All we need to check for is existence of AT LEAST one record. This can be done much faster with LIMIT 1.
