### PR TITLE
Fixes TypeError from `[]': no implicit conversion of Symbol into Integer

### DIFF
--- a/lib/rolify/railtie.rb
+++ b/lib/rolify/railtie.rb
@@ -3,7 +3,7 @@ require 'rails'
 
 module Rolify
   class Railtie < Rails::Railtie
-    initializer 'rolify.initialize', :after do
+    initializer 'rolify.initialize', {:after => 'rolify.initialize'} do
       ActiveSupport.on_load(:active_record) do
         ActiveRecord::Base.send :extend, Rolify
       end


### PR DESCRIPTION
After stepping through the debugger I saw that this was passing :after instead of {:after => 'rolify.initialize'} - causing the railties initializer to blow up.
