### PR TITLE
don't check DB when precompiling assets

### DIFF
--- a/lib/rolify/configure.rb
+++ b/lib/rolify/configure.rb
@@ -42,6 +42,8 @@ module Rolify
     private
     
     def sanity_check(role_cnames)
+      return true if "assets:precompile"==ARGV[0]
+
       role_cnames = [ "Role" ] if role_cnames.empty?
       role_cnames.each do |role_cname|
         role_class = role_cname.constantize


### PR DESCRIPTION
this is necessary on heroku, where the environment config is not available when precompiling
- it's not tested yet
- maybe this should be a more general solution that covers more cases? maybe it should check if currently inside _any_ rake task?
