### PR TITLE
fixes #168 - ensure rolify fails if roles table is missing

### DIFF
--- a/lib/rolify/configure.rb
+++ b/lib/rolify/configure.rb
@@ -2,7 +2,7 @@ module Rolify
   module Configure
     @@dynamic_shortcuts = false
     @@orm = "active_record"
-     
+
     def configure(*role_cnames)
       return if !sanity_check(role_cnames)
       yield self if block_given?
@@ -27,7 +27,7 @@ module Rolify
     def use_mongoid
       self.orm = "mongoid"
     end
-    
+
     def use_dynamic_shortcuts
       self.dynamic_shortcuts = true
     end
@@ -38,9 +38,9 @@ module Rolify
         config.orm = "active_record"
       end
     end
-    
+
     private
-    
+
     def sanity_check(role_cnames)
       role_cnames = [ "Role" ] if role_cnames.empty?
       role_cnames.each do |role_cname|
@@ -52,9 +52,9 @@ module Rolify
       end
       true
     end
-    
+
     def role_table_missing?(role_class)
-      role_class.connected? && !role_class.table_exists?
+      !role_class.table_exists?
     end
   end
 end


### PR DESCRIPTION
While setting up the application in a new environment, I get stuck after my User model calls `rolify`.  I'm also using Devise with the same User model as the one calling `rolify`.  Devise gets initialized after running `rake:db:migrate`, loads the User model, and causes the rolify line to raise a `PG::UndefinedTable: ERROR: relation "roles" does not exist` exception. 

A `sanity_check` method was created in the first fix to #168 but did not fix the issue for me.  Here, I fix it by making sure that if the roles table does not exist, `role_table_missing?(role_class)` will always return `true` rather than returning `false` for a missing database connection.