### PR TITLE
Fix select(:id) in active_record/resource_adapterto avoid Mysql2::Error: Column 'id' in field list is ambiguous

### DIFF
--- a/lib/rolify/adapters/active_record/resource_adapter.rb
+++ b/lib/rolify/adapters/active_record/resource_adapter.rb
@@ -12,7 +12,7 @@ module Rolify
       end
 
       def in(relation, user, role_names)
-        roles = user.roles.where(:name => role_names).select(:id)
+        roles = user.roles.where(:name => role_names).select(:'roles.id')
         relation.where("#{quote(role_class.table_name)}.#{role_class.primary_key} IN (?) AND ((resource_id = #{quote(relation.table_name)}.#{relation.primary_key}) OR (resource_id IS NULL))", roles)
       end
 


### PR DESCRIPTION
I've got the following error with rolify-3.4.0 and rails 4.0.4:

```
ActiveRecord::StatementInvalid: Mysql2::Error: Column 'id' in field list is ambiguous: SELECT `folders`.* FROM `folders` INNER JOIN `roles` ON `roles`.resource_type = 'Folder' AND
                                    (`roles`.resource_id IS NULL OR `roles`.resource_id = `folders`.id) WHERE (`roles`.name IN ('collaborate','informed') AND `roles`.resource_type = 'Folder') AND (`roles`.id IN (SELECT id FROM `roles` INNER JOIN `users_roles` ON `roles`.`id` = `users_roles`.`role_id` WHERE `users_roles`.`user_id` = 2 AND `roles`.`name` IN ('collaborate', 'informed')  ORDER BY roles.resource_type, roles.name) AND ((resource_id = `folders`.id) OR (resource_id IS NULL)))
```

It is caused by the changed line. In the generated SQL the problem is `SELECT id FROM `roles` in the middle. Please merge the fix.
