### PR TITLE
Fixed: ActiveRecord migration being generated without an extension

### DIFF
--- a/lib/generators/active_record/rolify_generator.rb
+++ b/lib/generators/active_record/rolify_generator.rb
@@ -17,7 +17,7 @@ module ActiveRecord
       end
       
       def copy_rolify_migration
-        migration_template "migration.rb", "db/migrate/rolify_create_#{table_name}"
+        migration_template "migration.rb", "db/migrate/rolify_create_#{table_name}.rb"
       end
       
       def join_table


### PR DESCRIPTION
AR migration for the gem was generated without a `.rb` extension. This PR fixes that.
