### PR TITLE
Allow Inheritance of Resources

### DIFF
--- a/lib/rolify.rb
+++ b/lib/rolify.rb
@@ -33,6 +33,11 @@ module Rolify
     load_dynamic_methods if Rolify.dynamic_shortcuts
   end
 
+  def adapter
+    return self.superclass.adapter unless self.instance_variable_defined? '@adapter'
+    @adapter
+  end
+
   def resourcify(association_name = :roles, options = {})
     include Resource
 
@@ -52,6 +57,7 @@ module Rolify
   end
 
   def role_class
+    return self.superclass.role_class unless self.instance_variable_defined? '@role_cname'
     self.role_cname.constantize
   end
 end

--- a/lib/rolify/adapters/active_record/resource_adapter.rb
+++ b/lib/rolify/adapters/active_record/resource_adapter.rb
@@ -3,10 +3,23 @@ require 'rolify/adapters/base'
 module Rolify
   module Adapter
     class ResourceAdapter < ResourceAdapterBase
+      def find_roles(role_name, relation, user)
+        roles = user && (user != :any) ? user.roles : self.role_class
+        roles = roles.where('resource_type IN (?)', self.relation_types_for(relation))
+        roles = roles.where(:name => role_name.to_s) if role_name && (role_name != :any)
+        roles
+      end
+
       def resources_find(roles_table, relation, role_name)
-        resources = relation.joins("INNER JOIN #{quote(roles_table)} ON #{quote(roles_table)}.resource_type = '#{relation.to_s}' AND
+        klasses   = self.relation_types_for(relation)
+        relations = klasses.inject('') do |str, klass|
+          str = "#{str}#{quote(klass.to_s)}"
+          str << ', ' unless klass == klasses.last
+          str
+        end
+        resources = relation.joins("INNER JOIN #{quote(roles_table)} ON #{quote(roles_table)}.resource_type IN (#{relations}) AND
                                     (#{quote(roles_table)}.resource_id IS NULL OR #{quote(roles_table)}.resource_id = #{quote(relation.table_name)}.#{relation.primary_key})")
-        resources = resources.where("#{quote(roles_table)}.name IN (?) AND #{quote(roles_table)}.resource_type = ?", Array(role_name), relation.to_s)
+        resources = resources.where("#{quote(roles_table)}.name IN (?) AND #{quote(roles_table)}.resource_type IN (?)", Array(role_name), klasses)
         resources = resources.select("#{quote(relation.table_name)}.*")
         resources
       end
@@ -16,10 +29,18 @@ module Rolify
         relation.where("#{quote(role_class.table_name)}.#{role_class.primary_key} IN (?) AND ((resource_id = #{quote(relation.table_name)}.#{relation.primary_key}) OR (resource_id IS NULL))", roles)
       end
 
+      def applied_roles(relation, children)
+        if children
+          relation.role_class.where('resource_type IN (?) AND resource_id IS NULL', self.relation_types_for(relation))
+        else
+          relation.role_class.where('resource_type = ? AND resource_id IS NULL', relation.to_s)
+        end
+      end
+
       private
 
       def quote(column)
-         ActiveRecord::Base.connection.quote_column_name column
+        ActiveRecord::Base.connection.quote_column_name column
       end
     end
   end

--- a/lib/rolify/adapters/base.rb
+++ b/lib/rolify/adapters/base.rb
@@ -23,6 +23,10 @@ module Rolify
         load "rolify/adapters/#{Rolify.orm}/scopes.rb"
         Rolify::Adapter.const_get(adapter.camelize.to_sym).new(role_cname, user_cname)
       end
+
+      def relation_types_for(relation)
+        relation.descendants.map(&:to_s).push(relation.to_s)
+      end
     end
 
     class RoleAdapterBase < Adapter::Base

--- a/lib/rolify/adapters/mongoid/resource_adapter.rb
+++ b/lib/rolify/adapters/mongoid/resource_adapter.rb
@@ -3,8 +3,16 @@ require 'rolify/adapters/base'
 module Rolify
   module Adapter
     class ResourceAdapter < ResourceAdapterBase
+
+      def find_roles(role_name, relation, user)
+        roles = user && (user != :any) ? user.roles : self.role_class
+        roles = roles.where(:resource_type.in => self.relation_types_for(relation))
+        roles = roles.where(:name => role_name.to_s) if role_name && (role_name != :any)
+        roles
+      end
+
       def resources_find(roles_table, relation, role_name)
-        roles = roles_table.classify.constantize.where(:name.in => Array(role_name), :resource_type => relation.to_s)
+        roles = roles_table.classify.constantize.where(:name.in => Array(role_name), :resource_type.in => self.relation_types_for(relation))
         resources = []
         roles.each do |role|
           if role.resource_id.nil?
@@ -22,6 +30,15 @@ module Rolify
         resources.delete_if { |resource| (resource.applied_roles & roles).empty? }
         resources
       end
+
+      def applied_roles(relation, children)
+        if children
+          relation.role_class.where(:resource_type.in => self.relation_types_for(relation), :resource_id => nil)
+        else
+          relation.role_class.where(:resource_type => relation.to_s, :resource_id => nil)
+        end
+      end
+
     end
   end
 end

--- a/lib/rolify/resource.rb
+++ b/lib/rolify/resource.rb
@@ -6,10 +6,7 @@ module Rolify
 
     module ClassMethods
       def find_roles(role_name = nil, user = nil)
-        roles = user && (user != :any) ? user.roles : self.role_class
-        roles = roles.where(:resource_type => self.to_s)
-        roles = roles.where(:name => role_name.to_s) if role_name && (role_name != :any)
-        roles
+        self.adapter.find_roles(role_name, self, user)
       end
 
       def with_role(role_name, user = nil)
@@ -23,10 +20,15 @@ module Rolify
         user ? self.adapter.in(resources, user, role_name) : resources
       end
       alias :with_roles :with_role
+
+      def applied_roles(children = true)
+        self.adapter.applied_roles(self, children)
+      end
     end
 
     def applied_roles
-      self.roles + self.class.role_class.where(:resource_type => self.class.to_s, :resource_id => nil)
+      #self.roles + self.class.role_class.where(:resource_type => self.class.to_s, :resource_id => nil)
+      self.roles + self.class.applied_roles(true)
     end
   end
 end

--- a/spec/rolify/config_spec.rb
+++ b/spec/rolify/config_spec.rb
@@ -183,7 +183,6 @@ describe Rolify do
       end
 
       subject { Forum }
-      
       it { should satisfy { |u| u.include? Rolify::Resource }}
       its("adapter.class") { should be(Rolify::Adapter::ResourceAdapter) }
     end

--- a/spec/rolify/resource_spec.rb
+++ b/spec/rolify/resource_spec.rb
@@ -7,6 +7,7 @@ describe Rolify::Resource do
     Forum.resourcify
     Group.resourcify
     Team.resourcify
+    Organization.resourcify
     Role.destroy_all
   end
 
@@ -24,6 +25,7 @@ describe Rolify::Resource do
   let!(:sneaky_role)     { tourist.add_role(:group, Forum.first) }
   let!(:captain_role)    { captain.add_role(:captain, Team.first) }
   let!(:player_role)     { captain.add_role(:player, Team.last) }
+  let!(:company_role)    { admin.add_role(:owner, Company.first) }
 
   describe ".with_roles" do
     subject { Group }
@@ -144,6 +146,13 @@ describe Rolify::Resource do
 
       it "should find Team instance using team_code column" do
         subject.with_roles([:captain, :player], captain).should =~ [ Team.first, Team.last ]
+      end
+    end
+
+    context "with a resource using STI" do
+      subject { Organization }
+      it "should find instances of children classes" do
+        subject.with_roles(:owner, admin).should =~ [ Company.first ]
       end
     end
   end
@@ -334,6 +343,13 @@ describe Rolify::Resource do
             subject.find_roles(:any, :any).should_not include(forum_role, godfather_role, tourist_role, sneaky_role)
           end
         end
+      end
+    end
+
+    context "with a resource using STI" do
+      subject{ Organization }
+      it "should find instances of children classes" do
+        subject.find_roles(:owner, admin).should =~ [company_role]
       end
     end
   end

--- a/spec/support/adapters/active_record.rb
+++ b/spec/support/adapters/active_record.rb
@@ -74,3 +74,11 @@ class Team < ActiveRecord::Base
 
   default_scope { order(:team_code) }
 end
+
+class Organization < ActiveRecord::Base
+
+end
+
+class Company < Organization
+
+end

--- a/spec/support/adapters/mongoid.rb
+++ b/spec/support/adapters/mongoid.rb
@@ -141,3 +141,11 @@ class Team
   field :team_code, :type => Integer
   field :name, :type => String
 end
+
+class Organization
+  include Mongoid::Document
+end
+
+class Company < Organization
+
+end

--- a/spec/support/data.rb
+++ b/spec/support/data.rb
@@ -23,3 +23,6 @@ Group.create(:name => "group 2")
 
 Team.create(:team_code => "1", :name => "PSG")
 Team.create(:team_code => "2", :name => "MU")
+
+Organization.create
+Company.create

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -49,4 +49,8 @@ ActiveRecord::Schema.define do
     t.primary_key :team_code
     t.string :name
   end
+
+  create_table(:organizations) do |t|
+    t.string :type
+  end
 end


### PR DESCRIPTION
This allows to have resources with subclasses and still be able to `find_roles` or `roles_with`.

Rspec provided, all tests pass over here (both AR and mongoid).

The base scenario is this:

```
class Organization
  include Mongoid::Document
  resourcify
end

class Company < Organization
end

user.add_role :owner, Company.create
```

before this commit, doing

```
Organization.with_roles(:owner, user) #(same for find_roles)
=> [] 
```

  No more!! :)

  No interface were changed except that now resource classes have a `applied_roles` method with a children parameter set to `true` by default.

So doing

```
Organization.applied_roles 
=> [:owner]
```

while

```
Organization.applied_roles(false)  
=> []
```
