### PR TITLE
Addition test for User finders with STI resources

### DIFF
--- a/spec/rolify/shared_contexts.rb
+++ b/spec/rolify/shared_contexts.rb
@@ -79,6 +79,7 @@ shared_context "mixed scoped roles", :scope => :mixed do
   let!(:root) { provision_user(user_class.first, [ :admin, :staff, [ :moderator, Group ], [ :visitor, Forum.last ] ]) }
   let!(:modo) { provision_user(user_class.where(:login => "moderator").first, [[ :moderator, Forum ], [ :manager, Group ], [ :visitor, Group.first ]])}
   let!(:visitor) { provision_user(user_class.last, [[ :visitor, Forum.last ]]) }
+  let!(:owner) { provision_user(user_class.first, [[:owner, Company.first]]) }
 end
 
 def create_other_roles

--- a/spec/rolify/shared_examples/shared_examples_for_finders.rb
+++ b/spec/rolify/shared_examples/shared_examples_for_finders.rb
@@ -42,6 +42,10 @@ shared_examples_for :finders do |param_name, param_method|
           it { subject.with_role("moderator".send(param_method), Group.first).should eq([ root ]) }
           it { subject.with_role("visitor".send(param_method), Group.first).should eq([ modo ]) }
         end
+
+        context "on Company.first_instance" do
+          it { subject.with_role("owner".send(param_method), Company.first).should eq([ owner ]) }
+        end
       end
     end
 

--- a/spec/rolify/shared_examples/shared_examples_for_roles.rb
+++ b/spec/rolify/shared_examples/shared_examples_for_roles.rb
@@ -17,6 +17,7 @@ shared_examples_for Rolify::Role do
     role_class.destroy_all
     Forum.resourcify :roles, :role_cname => role_class.to_s
     Group.resourcify :roles, :role_cname => role_class.to_s
+    Organization.resourcify :roles, :role_cname => role_class.to_s
   end
 
   context "in the Instance level" do


### PR DESCRIPTION
This is an addition to my previous commit to handle Resources with sub classes.

It only adds a test to ensure that doing 

```
User.with_role(:owner, Company.first)
```

works too.

No code outside specs are changed.
