### PR TITLE
Fixes quoting for STI.

### DIFF
--- a/lib/rolify/adapters/active_record/resource_adapter.rb
+++ b/lib/rolify/adapters/active_record/resource_adapter.rb
@@ -13,7 +13,7 @@ module Rolify
       def resources_find(roles_table, relation, role_name)
         klasses   = self.relation_types_for(relation)
         relations = klasses.inject('') do |str, klass|
-          str = "#{str}#{quote(klass.to_s)}"
+          str = "#{str}'#{klass.to_s}'"
           str << ', ' unless klass == klasses.last
           str
         end


### PR DESCRIPTION
Query used to look like this:

``` SQL
SELECT `groups`.* FROM `groups` INNER JOIN `roles` ON `roles`.resource_type IN (`Campus`, `Group`) AND
                                    (`roles`.resource_id IS NULL OR `roles`.resource_id = `groups`.id) WHERE (`roles`.name IN ('group_insight') AND `roles`.resource_type IN ('Campus','Group')) AND (`roles`.id IN (SELECT `roles`.id FROM `roles` INNER JOIN `users_roles` ON `roles`.`id` = `users_roles`.`role_id` WHERE `users_roles`.`user_id` = 26098 AND `roles`.`name` = 'group_insight') AND ((resource_id = `groups`.id) OR (resource_id IS NULL)))
```

This caused a Unknown column 'Group' in 'on clause'

Should now generate the correct:

``` SQL
SELECT `groups`.* FROM `groups` INNER JOIN `roles` ON `roles`.resource_type IN ('Campus', 'Group') AND
                                    (`roles`.resource_id IS NULL OR `roles`.resource_id = `groups`.id) WHERE (`roles`.name IN ('group_insight') AND `roles`.resource_type IN ('Campus','Group')) AND (`roles`.id IN (SELECT `roles`.id FROM `roles` INNER JOIN `users_roles` ON `roles`.`id` = `users_roles`.`role_id` WHERE `users_roles`.`user_id` = 26098 AND `roles`.`name` = 'group_insight') AND ((resource_id = `groups`.id) OR (resource_id IS NULL)))
```
