### PR TITLE
some failing tests to show that #has_role? does not re-check the state

### DIFF
--- a/spec/rolify/shared_examples/shared_examples_for_has_role.rb
+++ b/spec/rolify/shared_examples/shared_examples_for_has_role.rb
@@ -28,6 +28,20 @@ shared_examples_for "#has_role?_examples" do |param_name, param_method|
         it { subject.has_role?("dummy".send(param_method)).should be_falsey }
         it { subject.has_role?("dumber".send(param_method), Forum.first).should be_falsey }
       end
+
+      context "with a change in role" do
+        it "should be able to remove a role, then check" do
+          subject.has_role?("admin".send(param_method), Forum).should be_truthy
+          subject.remove_role("admin".send(param_method), Forum)
+          subject.has_role?("admin".send(param_method), Forum).should be_falsey
+        end
+
+        it "should be able to add a role, then check" do
+          subject.has_role?("dummy".send(param_method)).should be_falsey
+          subject.add_role("dummy".send(param_method))
+          subject.has_role?("dummy".send(param_method)).should be_truthy
+        end
+      end
     end
 
     context "with a class scoped role", :scope => :class do


### PR DESCRIPTION
The issue is this: 

> When running `#has_role?` successively, with an `#add_role` or `#remove_role` in between, it can return the wrong answer.

This starts in commit b6e76b5817d428850ba9747a2a872c830aa17088, so I would say it is due to the usage of the global variable `@r_map`. It is important to note that this variable will not be overwritten even by a `#reload` of the user object.

I think the reason for this behavior has not created issues is that you generally only want to run `#has_role?` once per query - within which the `@r_map` is set. I still think this is bad since someone out there may accidentally call the method before and after a change in roles.