### PR TITLE
cache mechanism is not complet and cause edge case

### DIFF
--- a/lib/rolify/role.rb
+++ b/lib/rolify/role.rb
@@ -3,11 +3,11 @@ require "rolify/finders"
 module Rolify
   module Role
     extend Utils
-    
+
     def self.included(base)
       base.extend Finders
     end
-          
+
     def add_role(role_name, resource = nil)
       role = self.class.adapter.find_or_create_by(role_name.to_s,
                                                   (resource.is_a?(Class) ? resource.to_s : resource.class.name if resource),
@@ -23,17 +23,11 @@ module Rolify
     deprecate :has_role, :add_role
 
     def has_role?(role_name, resource = nil)
-      @r_map ||= {}
-      role_n_resource = role_name.to_s + resource.to_s
-      @r_map[role_n_resource].nil? ? @r_map[role_n_resource] = has_role_helper(role_name, resource) : @r_map[role_n_resource]
-    end
-
-    def has_role_helper(role_name, resource = nil)
       if new_record?
-        self.roles.detect { |r| r.name == role_name.to_s && (r.resource == resource || resource.nil?) }.present?
+        self.roles.detect { |r| r.name.to_s == role_name.to_s && (r.resource == resource || resource.nil?) }
       else
-        self.class.adapter.where(self.roles, :name => role_name, :resource => resource).size > 0
-      end
+        self.class.adapter.where(self.roles, name: role_name, resource: resource)
+      end.present?
     end
 
     def has_all_roles?(*args)
@@ -56,7 +50,7 @@ module Rolify
         self.class.adapter.where(self.roles, *args).size > 0
       end
     end
-    
+
     def only_has_role?(role_name, resource = nil)
       return self.has_role?(role_name,resource) && self.roles.count == 1
     end
@@ -64,7 +58,7 @@ module Rolify
     def remove_role(role_name, resource = nil)
       self.class.adapter.remove(self, role_name.to_s, resource)
     end
-    
+
     alias_method :revoke, :remove_role
     deprecate :has_no_role, :remove_role
 

--- a/spec/rolify/role_spec.rb
+++ b/spec/rolify/role_spec.rb
@@ -12,9 +12,19 @@ describe Rolify do
   def role_class
     Role
   end
-  
+
   it_behaves_like Rolify::Role
   it_behaves_like "Role.scopes"
   it_behaves_like Rolify::Dynamic
   it_behaves_like "Rolify.callbacks"
+
+  context 'cache', pending: true do
+    let(:user) { User.first }
+    before { user.grant(:zombie) }
+    specify do
+      expect(user).to have_role(:zombie)
+      user.remove_role(:zombie)
+      expect(user).to_not have_role(:zombie)
+    end
+  end
 end


### PR DESCRIPTION
When you remove role, method `has_role?` provide wrong information.
```
user = FactoryGirl.build(:user)
user.has_role?(:foo)
# => false
user.grant(:foo)
user.has_role?(:foo)
# => false
>> psy.roles.map { |r| r.name }
=> ["foo"]
```

You can try this
```
bundle exec rspec spec/rolify/role_spec.rb -e 'Rolify cache'
```