### PR TITLE
Add Resource#with_roles example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Forum.with_role(:admin)
 # => [ list of Forum instances that has role "admin" binded to it ] 
 Forum.with_role(:admin, current_user)
 # => [ list of Forum instances that has role "admin" binded to it and belongs to current_user roles ]
+Forum.with_roles([:admin, :user], current_user)
+# => [ list of Forum instances that has role "admin" or "user" binded to it and belongs to current_user roles ]
 
 User.with_any_role(:user, :admin)
 # => [ list of User instances that has role "admin" or "user" binded to it ]


### PR DESCRIPTION
This was a feature I was looking for and found by reading the source. It might be helpful to include an example here.
