### PR TITLE
Remove role only if needed

### DIFF
--- a/lib/rolify/adapters/active_record/role_adapter.rb
+++ b/lib/rolify/adapters/active_record/role_adapter.rb
@@ -25,7 +25,7 @@ module Rolify
           relation.roles.delete(roles)
           roles.each do |role|
             role.destroy if role.send(ActiveSupport::Inflector.demodulize(user_class).tableize.to_sym).limit(1).empty?
-          end
+          end if Rolify.remove_role_if_empty
         end
         roles
       end

--- a/lib/rolify/configure.rb
+++ b/lib/rolify/configure.rb
@@ -2,7 +2,8 @@ module Rolify
   module Configure
     @@dynamic_shortcuts = false
     @@orm = "active_record"
-     
+    @@remove_role_if_empty = true
+
     def configure(*role_cnames)
       return if !sanity_check(role_cnames)
       yield self if block_given?
@@ -27,7 +28,7 @@ module Rolify
     def use_mongoid
       self.orm = "mongoid"
     end
-    
+
     def use_dynamic_shortcuts
       self.dynamic_shortcuts = true
     end
@@ -38,9 +39,17 @@ module Rolify
         config.orm = "active_record"
       end
     end
-    
+
+    def remove_role_if_empty=(is_remove)
+      @@remove_role_if_empty = is_remove
+    end
+
+    def remove_role_if_empty
+      @@remove_role_if_empty
+    end
+
     private
-    
+
     def sanity_check(role_cnames)
       return true if "assets:precompile"==ARGV[0]
 
@@ -54,7 +63,7 @@ module Rolify
       end
       true
     end
-    
+
     def role_table_missing?(role_class)
       role_class.connected? && !role_class.table_exists?
     end


### PR DESCRIPTION
Sometimes user does not want remove "global" role if role does not have a relation. It seems, it is useful for save global role and show on the view for choose this role again.   
