### PR TITLE
Add validation on Role#resource_type

### DIFF
--- a/lib/generators/active_record/rolify_generator.rb
+++ b/lib/generators/active_record/rolify_generator.rb
@@ -5,42 +5,44 @@ module ActiveRecord
   module Generators
     class RolifyGenerator < ActiveRecord::Generators::Base
       source_root File.expand_path("../templates", __FILE__)
-      
+
       argument :user_cname, :type => :string, :default => "User", :banner => "User"
-      
+
       def generate_model
         invoke "active_record:model", [ name ], :migration => false
       end
-      
+
       def inject_role_class
         inject_into_class(model_path, class_name, model_content)
       end
-      
+
       def copy_rolify_migration
         migration_template "migration.rb", "db/migrate/rolify_create_#{table_name}.rb"
       end
-      
+
       def join_table
         user_cname.constantize.table_name + "_" + table_name
       end
-      
+
       def user_reference
         user_cname.demodulize.underscore
       end
-      
+
       def role_reference
         class_name.demodulize.underscore
       end
-      
+
       def model_path
         File.join("app", "models", "#{file_path}.rb")
       end
-      
+
       def model_content
         content = <<RUBY
   has_and_belongs_to_many :%{user_cname}, :join_table => :%{join_table}
   belongs_to :resource, :polymorphic => true
-  
+
+  validates :resource_type, :inclusion => { :in => Rolify.resource_types }
+
   scopify
 RUBY
         content % { :user_cname => user_cname.constantize.table_name, :join_table => "#{user_cname.constantize.table_name}_#{table_name}"}

--- a/lib/generators/mongoid/rolify_generator.rb
+++ b/lib/generators/mongoid/rolify_generator.rb
@@ -5,34 +5,34 @@ module Mongoid
   module Generators
     class RolifyGenerator < Rails::Generators::NamedBase
       source_root File.expand_path("../templates", __FILE__)
-      
+
       argument :user_cname, :type => :string, :default => "User", :banner => "User"
-      
+
       def generate_model
         invoke "mongoid:model", [ name ]
       end
-      
+
       def inject_role_class
         inject_into_file(model_path, model_contents, :after => "include Mongoid::Document\n")
       end
-      
+
       def user_reference
         user_cname.demodulize.underscore
       end
-      
+
       def role_reference
         class_name.demodulize.underscore
       end
-      
+
       def model_path
         File.join("app", "models", "#{file_path}.rb")
       end
-      
+
       def model_contents
         content = <<RUBY
   has_and_belongs_to_many :%{user_cname}
   belongs_to :resource, :polymorphic => true
-  
+
   field :name, :type => String
 
   index({
@@ -41,7 +41,9 @@ module Mongoid
     :resource_id => 1
   },
   { :unique => true})
-  
+
+  validates :resource_type, :inclusion => { :in => Rolify.resource_types }
+
   scopify
 RUBY
         content % { :user_cname => user_cname.constantize.collection_name }

--- a/lib/rolify.rb
+++ b/lib/rolify.rb
@@ -10,6 +10,7 @@ module Rolify
   extend Configure
 
   attr_accessor :role_cname, :adapter, :role_join_table_name, :role_table_name
+  @@resource_types = []
 
   def rolify(options = {})
     include Role
@@ -49,6 +50,7 @@ module Rolify
     has_many association_name, resourcify_options
 
     self.adapter = Rolify::Adapter::Base.create("resource_adapter", self.role_cname, self.name)
+    @@resource_types << self.name
   end
 
   def scopify
@@ -59,5 +61,9 @@ module Rolify
   def role_class
     return self.superclass.role_class unless self.instance_variable_defined? '@role_cname'
     self.role_cname.constantize
+  end
+
+  def self.resource_types
+    @@resource_types
   end
 end

--- a/spec/generators/rolify/rolify_activerecord_generator_spec.rb
+++ b/spec/generators/rolify/rolify_activerecord_generator_spec.rb
@@ -7,11 +7,11 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
   # Tell the generator where to put its output (what it thinks of as Rails.root)
   destination File.expand_path("../../../../tmp", __FILE__)
   teardown :cleanup_destination_root
-  
-  before { 
+
+  before {
     prepare_destination
   }
-  
+
   def cleanup_destination_root
     FileUtils.rm_rf destination_root
   end
@@ -19,7 +19,7 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
   describe 'specifying only Role class name' do
     before(:all) { arguments %w(Role) }
 
-    before { 
+    before {
       capture(:stdout) {
         generator.create_file "app/models/user.rb" do
           <<-RUBY
@@ -29,9 +29,9 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
         end
       }
       require File.join(destination_root, "app/models/user.rb")
-      run_generator 
+      run_generator
     }
-    
+
     describe 'config/initializers/rolify.rb' do
       subject { file('config/initializers/rolify.rb') }
       it { should exist }
@@ -39,23 +39,24 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
       it { should contain "# config.use_dynamic_shortcuts" }
       it { should contain "# config.use_mongoid" }
     end
-    
+
     describe 'app/models/role.rb' do
       subject { file('app/models/role.rb') }
       it { should exist }
       it { should contain "class Role < ActiveRecord::Base" }
       it { should contain "has_and_belongs_to_many :users, :join_table => :users_roles" }
       it { should contain "belongs_to :resource, :polymorphic => true" }
+      it { should contain "validates :resource_type, :inclusion => { :in => Rolify.resource_types }" }
     end
-    
+
     describe 'app/models/user.rb' do
       subject { file('app/models/user.rb') }
       it { should contain /class User < ActiveRecord::Base\n  rolify\n/ }
     end
-    
+
     describe 'migration file' do
       subject { migration_file('db/migrate/rolify_create_roles.rb') }
-      
+
       it { should be_a_migration }
       it { should contain "create_table(:roles) do" }
       it { should contain "create_table(:users_roles, :id => false) do" }
@@ -64,8 +65,8 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
 
   describe 'specifying User and Role class names' do
     before(:all) { arguments %w(AdminRole AdminUser) }
-    
-    before { 
+
+    before {
       capture(:stdout) {
         generator.create_file "app/models/admin_user.rb" do
           "class AdminUser < ActiveRecord::Base\nend"
@@ -74,44 +75,44 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
       require File.join(destination_root, "app/models/admin_user.rb")
       run_generator
     }
-    
+
     describe 'config/initializers/rolify.rb' do
       subject { file('config/initializers/rolify.rb') }
-      
+
       it { should exist }
       it { should contain "Rolify.configure(\"AdminRole\") do |config|"}
       it { should contain "# config.use_dynamic_shortcuts" }
       it { should contain "# config.use_mongoid" }
     end
-    
+
     describe 'app/models/admin_role.rb' do
       subject { file('app/models/admin_role.rb') }
-      
+
       it { should exist }
       it { should contain "class AdminRole < ActiveRecord::Base" }
       it { should contain "has_and_belongs_to_many :admin_users, :join_table => :admin_users_admin_roles" }
       it { should contain "belongs_to :resource, :polymorphic => true" }
     end
-    
+
     describe 'app/models/admin_user.rb' do
       subject { file('app/models/admin_user.rb') }
-      
+
       it { should contain /class AdminUser < ActiveRecord::Base\n  rolify :role_cname => 'AdminRole'\n/ }
     end
-    
+
     describe 'migration file' do
       subject { migration_file('db/migrate/rolify_create_admin_roles.rb') }
-      
+
       it { should be_a_migration }
       it { should contain "create_table(:admin_roles)" }
       it { should contain "create_table(:admin_users_admin_roles, :id => false) do" }
     end
   end
-  
+
   describe 'specifying namespaced User and Role class names' do
     before(:all) { arguments %w(Admin::Role Admin::User) }
-    
-    before { 
+
+    before {
       capture(:stdout) {
         generator.create_file "app/models/admin/user.rb" do
           <<-RUBY
@@ -126,34 +127,34 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
       require File.join(destination_root, "app/models/admin/user.rb")
       run_generator
     }
-    
+
     describe 'config/initializers/rolify.rb' do
       subject { file('config/initializers/rolify.rb') }
-      
+
       it { should exist }
       it { should contain "Rolify.configure(\"Admin::Role\") do |config|"}
       it { should contain "# config.use_dynamic_shortcuts" }
       it { should contain "# config.use_mongoid" }
     end
-    
+
     describe 'app/models/admin/role.rb' do
       subject { file('app/models/admin/role.rb') }
-      
+
       it { should exist }
       it { should contain "class Admin::Role < ActiveRecord::Base" }
       it { should contain "has_and_belongs_to_many :admin_users, :join_table => :admin_users_admin_roles" }
       it { should contain "belongs_to :resource, :polymorphic => true" }
     end
-    
+
     describe 'app/models/admin/user.rb' do
       subject { file('app/models/admin/user.rb') }
-      
+
       it { should contain /class User < ActiveRecord::Base\n  rolify :role_cname => 'Admin::Role'\n/ }
     end
-    
+
     describe 'migration file' do
       subject { migration_file('db/migrate/rolify_create_admin_roles.rb') }
-      
+
       it { should be_a_migration }
       it { should contain "create_table(:admin_roles)" }
       it { should contain "create_table(:admin_users_admin_roles, :id => false) do" }

--- a/spec/generators/rolify/rolify_mongoid_generator_spec.rb
+++ b/spec/generators/rolify/rolify_mongoid_generator_spec.rb
@@ -7,19 +7,19 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'mongoid'
   # Tell the generator where to put its output (what it thinks of as Rails.root)
   destination File.expand_path("../../../../tmp", __FILE__)
   teardown :cleanup_destination_root
-  
-  before { 
+
+  before {
     prepare_destination
   }
-  
+
   def cleanup_destination_root
     FileUtils.rm_rf destination_root
   end
 
-  describe 'specifying ORM adapter' do 
+  describe 'specifying ORM adapter' do
     before(:all) { arguments [ "Role", "User", "--orm=mongoid" ] }
-    
-    before { 
+
+    before {
       capture(:stdout) {
         generator.create_file "app/models/user.rb" do
 <<-RUBY
@@ -34,7 +34,7 @@ RUBY
       require File.join(destination_root, "app/models/user.rb")
       run_generator
     }
-      
+
     describe 'config/initializers/rolify.rb' do
       subject { file('config/initializers/rolify.rb') }
       it { should exist }
@@ -42,7 +42,7 @@ RUBY
       it { should_not contain "# config.use_mongoid" }
       it { should contain "# config.use_dynamic_shortcuts" }
     end
-    
+
     describe 'app/models/role.rb' do
       subject { file('app/models/role.rb') }
       it { should exist }
@@ -56,18 +56,19 @@ RUBY
                           "      { :resource_id => 1 }\n"
                           "    },\n"
                           "    { unique => true })"}
+      it { should contain "validates :resource_type, :inclusion => { :in => Rolify.resource_types }" }
     end
-    
+
     describe 'app/models/user.rb' do
       subject { file('app/models/user.rb') }
       it { should contain /class User\n  include Mongoid::Document\n  rolify\n/ }
     end
   end
-  
+
   describe 'specifying namespaced User and Role class names and ORM adapter' do
     before(:all) { arguments %w(Admin::Role Admin::User --orm=mongoid) }
-    
-    before { 
+
+    before {
       capture(:stdout) {
         generator.create_file "app/models/admin/user.rb" do
 <<-RUBY
@@ -82,28 +83,28 @@ RUBY
       require File.join(destination_root, "app/models/admin/user.rb")
       run_generator
     }
-    
+
     describe 'config/initializers/rolify.rb' do
       subject { file('config/initializers/rolify.rb') }
-      
+
       it { should exist }
       it { should contain "Rolify.configure(\"Admin::Role\") do |config|"}
       it { should contain "# config.use_dynamic_shortcuts" }
       it { should_not contain "# config.use_mongoid" }
     end
-    
+
     describe 'app/models/admin/role.rb' do
       subject { file('app/models/admin/role.rb') }
-      
+
       it { should exist }
       it { should contain "class Admin::Role" }
       it { should contain "has_and_belongs_to_many :admin_users" }
       it { should contain "belongs_to :resource, :polymorphic => true" }
     end
-    
+
     describe 'app/models/admin/user.rb' do
       subject { file('app/models/admin/user.rb') }
-      
+
       it { should contain /class User\n    include Mongoid::Document\n  rolify :role_cname => 'Admin::Role'\n/ }
     end
   end

--- a/spec/rolify/resource_spec.rb
+++ b/spec/rolify/resource_spec.rb
@@ -403,4 +403,12 @@ describe Rolify::Resource do
       its(:applied_roles) { should_not include(forum_role, godfather_role, sneaky_role, tourist_role) }
     end
   end
+
+  describe '.resource_types' do
+
+    it 'include all models that call resourcify' do
+      Rolify.resource_types.should include("HumanResource", "Forum", "Group",
+                                          "Team", "Organization")
+    end
+  end
 end


### PR DESCRIPTION
With this will avoid add a permission to a model that don't call the
`resourcify`.

Now every model that call `resourcify` has his name saved and can be
found on the `Rolify.resource_types`.

Since the Role model is generated by the generator it is possible to
remove this validation.
