### PR TITLE
FixBUG mongoid

### DIFF
--- a/lib/rolify/adapters/mongoid/resource_adapter.rb
+++ b/lib/rolify/adapters/mongoid/resource_adapter.rb
@@ -12,7 +12,7 @@ module Rolify
       end
 
       def resources_find(roles_table, relation, role_name)
-        roles = roles_table.classify.constantize.where(:name.in => Array(role_name), :resource_type.in => self.relation_types_for(relation))
+        roles = roles_table.classify.constantize.in(:name => Array(role_name), :resource_type => self.relation_types_for(relation))
         resources = []
         roles.each do |role|
           if role.resource_id.nil?

--- a/lib/rolify/resource.rb
+++ b/lib/rolify/resource.rb
@@ -16,7 +16,7 @@ module Rolify
           role_name = role_name.to_s
         end
 
-        resources = self.adapter.resources_find(self.role_table_name, self, role_name) #.map(&:id)
+        resources = self.adapter.resources_find(self.role_cname, self, role_name)
         user ? self.adapter.in(resources, user, role_name) : resources
       end
       alias :with_roles :with_role


### PR DESCRIPTION
Hi , 

With mongoid 4.0.0 , rails 4.1.8, i've a problem with "with_role" method.
In code "role_table_name" is used , but for mongoid with namespace it don't work..
In my case i've "Organization::Security::Role" classe name and when the method is called ,it use tableize  but it's wrong..
I've changed role_table_name by role_cname.

In mongoid adapter , i've changed the "where" into "in", in my case mongoid raise an query error for resource_type wiht where but not with in method

Michael
