### PR TITLE
Fix has_roles? method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rolify (3.5.0)
+    rolify (3.5.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     i18n (0.7.0)
     its (0.2.0)
       rspec-core
-    json (1.8.1)
+    json (1.8.2)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
     method_source (0.8.2)
@@ -71,7 +71,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rack (1.6.0)
-    rack-test (0.6.2)
+    rack-test (0.6.3)
       rack (>= 1.0)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)

--- a/lib/rolify/role.rb
+++ b/lib/rolify/role.rb
@@ -23,10 +23,13 @@ module Rolify
 
     def has_role?(role_name, resource = nil)
       if new_record?
-        self.roles.detect { |r| r.name.to_s == role_name.to_s && (r.resource == resource || resource.nil?) }
+        role_array = self.roles.detect { |r| r.name.to_s == role_name.to_s && (r.resource == resource || resource.nil?) }
       else
-        self.class.adapter.where(self.roles, name: role_name, resource: resource)
-      end.length > 0
+        role_array = self.class.adapter.where(self.roles, name: role_name, resource: resource)
+      end
+
+      return false if role_array.nil?
+      role_array != []
     end
 
     def has_all_roles?(*args)

--- a/lib/rolify/role.rb
+++ b/lib/rolify/role.rb
@@ -26,7 +26,7 @@ module Rolify
         self.roles.detect { |r| r.name.to_s == role_name.to_s && (r.resource == resource || resource.nil?) }
       else
         self.class.adapter.where(self.roles, name: role_name, resource: resource)
-      end.present?
+      end.length > 0
     end
 
     def has_all_roles?(*args)

--- a/lib/rolify/version.rb
+++ b/lib/rolify/version.rb
@@ -1,3 +1,3 @@
 module Rolify
-  VERSION = "3.5.0"
+  VERSION = "3.5.1"
 end


### PR DESCRIPTION
The has_roles? method was always returning true - even if the role didn't exist in the system.  This was because the if \ else statement had .present appended to it.  I have removed that and added some code that actually returns the correct value. 