### PR TITLE
Update bundler requirement for new version

### DIFF
--- a/rolify.gemspec
+++ b/rolify.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_development_dependency 'ammeter',     '~> 1.1.2' # Spec generator
-  s.add_development_dependency 'bundler',     '~> 1.7.12' # packaging feature
+  s.add_development_dependency 'bundler',     '>= 1.7.12' # packaging feature
   s.add_development_dependency 'rake',        '~> 10.4.2' # Tasks manager
   s.add_development_dependency 'rspec-rails', '2.99.0'
 end


### PR DESCRIPTION
Bundler 1.8.0 released Feb 10, and '~> 1.7.12' will only match 1.7.x. 

Specs passed with this change. 