### PR TITLE
Fix for #285 - dynamic_shortcuts can be set before table exists

### DIFF
--- a/lib/generators/rolify/templates/initializer.rb
+++ b/lib/generators/rolify/templates/initializer.rb
@@ -1,8 +1,7 @@
 Rolify.configure<%= "(\"#{class_name.camelize.to_s}\")" if class_name != "Role" %> do |config|
   # By default ORM adapter is ActiveRecord. uncomment to use mongoid
   <%= "# " if options.orm == :active_record || !options.orm %>config.use_mongoid
-  
+
   # Dynamic shortcuts for User class (user.is_admin? like methods). Default is: false
-  # Enable this feature _after_ running rake db:migrate as it relies on the roles table
   # config.use_dynamic_shortcuts
 end

--- a/lib/rolify/configure.rb
+++ b/lib/rolify/configure.rb
@@ -30,6 +30,7 @@ module Rolify
     end
 
     def use_dynamic_shortcuts
+      return if !sanity_check([])
       self.dynamic_shortcuts = true
     end
 

--- a/lib/rolify/configure.rb
+++ b/lib/rolify/configure.rb
@@ -65,7 +65,7 @@ module Rolify
     end
 
     def role_table_missing?(role_class)
-      role_class.connected? && !role_class.table_exists?
+      !role_class.table_exists?
     end
   end
 end


### PR DESCRIPTION
As per issue #285 (and listed in #300), `config.use_dynamic_shortcuts` being set to 'true' before migration (when a role table does not yet exist) causes an error. This is especially problematic for users using continuous integration tools. 

This PR addresses this by running the `sanity_check` method before allowing `use_dynamic_shortcuts` to be set true, thus allowing migrations (or any rake task that loads the Rails environment) to complete successfully (and output the warning contained within `sanity_check`).

Additionally, there are changes to the logic of `sanity_check` such that it only verifies the existence of the table, even if an Active Record connection does not yet exist. We potentially could `rescue` any ActiveRecord exceptions that bubble up from a lack of connection, however in testing this patch, I never saw any raised. In fact, when using this for `rake` tasks, `role_class.connected?` always returned false, and the call to `role_class.table_exists?` returned what we expected, so I suspect we don't actually need to `rescue` here.

Paired on this with @kerrizor