### PR TITLE
Allow all rake tasks with the 'assets' prefix to execute without config sanity check

### DIFF
--- a/lib/rolify/configure.rb
+++ b/lib/rolify/configure.rb
@@ -52,7 +52,7 @@ module Rolify
     private
 
     def sanity_check(role_cnames)
-      return true if "assets:precompile"==ARGV[0]
+      return true if (ARGV[0] =~ /assets:/) == 0
 
       role_cnames = [ "Role" ] if role_cnames.empty?
       role_cnames.each do |role_cname|


### PR DESCRIPTION
08900ad94ad7941a39cbf0cc3c419b9229637879 allowed for the `rake assets:precompile` command to skip through the `Rolify::Configure#sanity_check` method calls. We use a modified version of the `assets:precompile` rake task on a Rails app that I'm working on at work (with a slightly modified name), and so this sanity_check is causing errors for us.

I thought about it more and actually, shouldn't all rake tasks with the `assets:` prefix be allowed to skip this sanity check too? This PR will do just that.