### PR TITLE
Correct the tutorial link to the wiki.

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
 </div>
 
 
-<p>This library is generic enough to be used by any authentication/authorization solutions. Look at his <a href="https://github.com/RolifyCommunity/rolify/wiki/Tutorial">Tutorial</a> if you want to checkout an example showing how to integrate <a href="https://github.com/RolifyCommunity/rolify">rolify</a> with <a href="https://github.com/CanCanCommunity/cancancan">CanCanCan</a> and <a href="https://github.com/plataformatec/devise">Devise</a>.</p>
+<p>This library is generic enough to be used by any authentication/authorization solutions. Look at his <a href="https://github.com/RolifyCommunity/rolify/wiki/Devise---CanCanCan---rolify-Tutorial">Tutorial</a> if you want to checkout an example showing how to integrate <a href="https://github.com/RolifyCommunity/rolify">rolify</a> with <a href="https://github.com/CanCanCommunity/cancancan">CanCanCan</a> and <a href="https://github.com/plataformatec/devise">Devise</a>.</p>
 
 <h2>Dependencies</h2>
 


### PR DESCRIPTION
Just noticed that the tutorial link points to the wrong place. Figured I'd submit a PR to correct it. :)