### PR TITLE
Fix has_role? with :any and an unsaved user

### DIFF
--- a/lib/rolify/role.rb
+++ b/lib/rolify/role.rb
@@ -24,7 +24,12 @@ module Rolify
 
     def has_role?(role_name, resource = nil)
       if new_record?
-        role_array = self.roles.detect { |r| r.name.to_s == role_name.to_s && (r.resource == resource || resource.nil?) }
+        role_array = self.roles.detect { |r|
+          r.name.to_s == role_name.to_s &&
+            (r.resource == resource ||
+             resource.nil? ||
+             (resource == :any && r.resource.present?))
+        }
       else
         role_array = self.class.adapter.where(self.roles, name: role_name, resource: resource)
       end

--- a/spec/rolify/shared_examples/shared_examples_for_has_role.rb
+++ b/spec/rolify/shared_examples/shared_examples_for_has_role.rb
@@ -79,6 +79,11 @@ shared_examples_for "#has_role?_examples" do |param_name, param_method|
       context "on instance scoped role request" do
         it { subject.has_role?("moderator".send(param_method), Forum.first).should be_truthy }
         it { subject.has_role?("moderator".send(param_method), :any).should be_truthy }
+        it {
+          m = subject.class.new
+          m.add_role("moderator", Forum.first)
+          m.has_role?("moderator".send(param_method), :any).should be_truthy
+        }
       end
 
       it "should not get an instance scoped role when asking for a global" do


### PR DESCRIPTION
The code for unsaved users was returning false for `has_role?(:foo, :any)` when the user in fact had a matching role.

This commit includes a test but I wasn't sure how to fit tests on unsaved users into the existing specs, so feel free to move it.
