### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This library can be easily integrated with any authentication gem ([devise](http
 
 ## Installation
 
-In <b>Rails 3</b>, add this to your Gemfile and run the +bundle+ command.
+Add this to your Gemfile and run the +bundle+ command.
 
 ```ruby
 gem "rolify"


### PR DESCRIPTION
Removing the "In Rails 3" from **Installation** section since Rolify is also compatible with Rails 4 and the versions requirements is already specified in the **Requirements** section