### PR TITLE
Give resourcify its own dedicated adapter; alias identically-named methods (e.g. with_role)

### DIFF
--- a/lib/rolify.rb
+++ b/lib/rolify.rb
@@ -52,6 +52,11 @@ module Rolify
     @@resource_types << self.name
   end
 
+  def resource_adapter
+    return self.superclass.resource_adapter unless self.instance_variable_defined? '@resource_adapter'
+    @resource_adapter
+  end
+
   def scopify
     require "rolify/adapters/#{Rolify.orm}/scopes.rb"
     extend Rolify::Adapter::Scopes

--- a/lib/rolify.rb
+++ b/lib/rolify.rb
@@ -8,7 +8,7 @@ require 'rolify/role'
 module Rolify
   extend Configure
 
-  attr_accessor :role_cname, :adapter, :role_join_table_name, :role_table_name
+  attr_accessor :role_cname, :adapter, :resource_adapter, :role_join_table_name, :role_table_name
   @@resource_types = []
 
   def rolify(options = {})
@@ -48,7 +48,7 @@ module Rolify
 
     has_many association_name, resourcify_options
 
-    self.adapter = Rolify::Adapter::Base.create("resource_adapter", self.role_cname, self.name)
+    self.resource_adapter = Rolify::Adapter::Base.create("resource_adapter", self.role_cname, self.name)
     @@resource_types << self.name
   end
 

--- a/lib/rolify/resource.rb
+++ b/lib/rolify/resource.rb
@@ -9,7 +9,7 @@ module Rolify
         self.adapter.find_roles(role_name, self, user)
       end
 
-      def with_role(role_name, user = nil)
+      def find_as(role_name, user = nil)
         if role_name.is_a? Array
           role_name.map!(&:to_s)
         else
@@ -19,13 +19,13 @@ module Rolify
         resources = self.adapter.resources_find(self.role_table_name, self, role_name) #.map(&:id)
         user ? self.adapter.in(resources, user, role_name) : resources
       end
-      alias :with_roles :with_role
+      alias :find_as_multiple :find_as
 
 
-      def without_role(role_name, user = nil)
-        self.adapter.all_except(self, self.with_role(role_name, user))
+      def except_as(role_name, user = nil)
+        self.adapter.all_except(self, self.find_as(role_name, user))
       end
-      alias :without_roles :without_role
+      alias :except_as_multiple :except_as
 
 
 

--- a/lib/rolify/resource.rb
+++ b/lib/rolify/resource.rb
@@ -6,7 +6,7 @@ module Rolify
 
     module ClassMethods
       def find_roles(role_name = nil, user = nil)
-        self.adapter.find_roles(role_name, self, user)
+        self.resource_adapter.find_roles(role_name, self, user)
       end
 
       def find_as(role_name, user = nil)
@@ -16,21 +16,21 @@ module Rolify
           role_name = role_name.to_s
         end
 
-        resources = self.adapter.resources_find(self.role_table_name, self, role_name) #.map(&:id)
-        user ? self.adapter.in(resources, user, role_name) : resources
+        resources = self.resource_adapter.resources_find(self.role_table_name, self, role_name) #.map(&:id)
+        user ? self.resource_adapter.in(resources, user, role_name) : resources
       end
       alias :find_as_multiple :find_as
 
 
       def except_as(role_name, user = nil)
-        self.adapter.all_except(self, self.find_as(role_name, user))
+        self.resource_adapter.all_except(self, self.find_as(role_name, user))
       end
       alias :except_as_multiple :except_as
 
 
 
       def applied_roles(children = true)
-        self.adapter.applied_roles(self, children)
+        self.resource_adapter.applied_roles(self, children)
       end
 
 

--- a/lib/rolify/resource.rb
+++ b/lib/rolify/resource.rb
@@ -9,7 +9,7 @@ module Rolify
         self.resource_adapter.find_roles(role_name, self, user)
       end
 
-      def find_as(role_name, user = nil)
+      def with_role(role_name, user = nil)
         if role_name.is_a? Array
           role_name.map!(&:to_s)
         else
@@ -19,13 +19,17 @@ module Rolify
         resources = self.resource_adapter.resources_find(self.role_table_name, self, role_name) #.map(&:id)
         user ? self.resource_adapter.in(resources, user, role_name) : resources
       end
-      alias :find_as_multiple :find_as
+      alias :with_roles :with_role
+      alias :find_as :with_role 
+      alias :find_multiple_as :with_role
 
 
-      def except_as(role_name, user = nil)
+      def without_role(role_name, user = nil)
         self.resource_adapter.all_except(self, self.find_as(role_name, user))
       end
-      alias :except_as_multiple :except_as
+      alias :without_roles :without_role
+      alias :except_as :without_role 
+      alias :except_multiple_as :without_role 
 
 
 

--- a/spec/rolify/config_spec.rb
+++ b/spec/rolify/config_spec.rb
@@ -57,7 +57,7 @@ describe Rolify do
         
         subject { Forum }
         
-        its("adapter.class") { should be(Rolify::Adapter::ResourceAdapter) }
+        its("resource_adapter.class") { should be(Rolify::Adapter::ResourceAdapter) }
       end
     end
 
@@ -88,7 +88,7 @@ describe Rolify do
 
           subject { Forum }
 
-          its("adapter.class") { should be(Rolify::Adapter::ResourceAdapter) }
+          its("resource_adapter.class") { should be(Rolify::Adapter::ResourceAdapter) }
         end
       end
       
@@ -118,7 +118,7 @@ describe Rolify do
 
           subject { Forum }
 
-          its("adapter.class") { should be(Rolify::Adapter::ResourceAdapter) }
+          its("resource_adapter.class") { should be(Rolify::Adapter::ResourceAdapter) }
         end
       end
     end
@@ -184,7 +184,7 @@ describe Rolify do
 
       subject { Forum }
       it { should satisfy { |u| u.include? Rolify::Resource }}
-      its("adapter.class") { should be(Rolify::Adapter::ResourceAdapter) }
+      its("resource_adapter.class") { should be(Rolify::Adapter::ResourceAdapter) }
     end
   end
 end

--- a/spec/rolify/resource_spec.rb
+++ b/spec/rolify/resource_spec.rb
@@ -27,7 +27,7 @@ describe Rolify::Resource do
   let!(:player_role)     { captain.add_role(:player, Team.last) }
   let!(:company_role)    { admin.add_role(:owner, Company.first) }
 
-  describe ".with_roles" do
+  describe ".find_as_multiple" do
     subject { Group }
 
     it { should respond_to(:find_roles).with(1).arguments }
@@ -38,15 +38,15 @@ describe Rolify::Resource do
         subject { Forum }
 
         it "should include Forum instances with forum role" do
-          subject.with_role(:forum).should =~ [ Forum.first, Forum.last ]
+          subject.find_as(:forum).should =~ [ Forum.first, Forum.last ]
         end
 
         it "should include Forum instances with godfather role" do
-          subject.with_role(:godfather).should =~ Forum.all
+          subject.find_as(:godfather).should =~ Forum.all
         end
 
         it "should be able to modify the resource", :if => ENV['ADAPTER'] == 'active_record' do
-          forum_resource = subject.with_role(:forum).first
+          forum_resource = subject.find_as(:forum).first
           forum_resource.name = "modified name"
           expect { forum_resource.save }.not_to raise_error
         end
@@ -56,7 +56,7 @@ describe Rolify::Resource do
         subject { Group }
 
         it "should include Group instances with group role" do
-          subject.with_role(:group).should =~ [ Group.last ]
+          subject.find_as(:group).should =~ [ Group.last ]
         end
       end
 
@@ -64,7 +64,7 @@ describe Rolify::Resource do
         subject { Group.last }
 
         it "should ignore nil entries" do
-          subject.subgroups.with_role(:group).should =~ [ ]
+          subject.subgroups.find_as(:group).should =~ [ ]
         end
       end
     end
@@ -74,7 +74,7 @@ describe Rolify::Resource do
         subject { Group }
 
         it "should include Group instances with both group and grouper roles" do
-          subject.with_roles([:group, :grouper]).should =~ [ Group.first, Group.last ]
+          subject.find_as_multiple([:group, :grouper]).should =~ [ Group.first, Group.last ]
         end
       end
     end
@@ -84,27 +84,27 @@ describe Rolify::Resource do
         subject { Forum }
 
         it "should get all Forum instances binded to the forum role and the admin user" do
-          subject.with_role(:forum, admin).should =~ [ Forum.first ]
+          subject.find_as(:forum, admin).should =~ [ Forum.first ]
         end
 
         it "should get all Forum instances binded to the forum role and the tourist user" do
-          subject.with_role(:forum, tourist).should =~ [ Forum.last ]
+          subject.find_as(:forum, tourist).should =~ [ Forum.last ]
         end
 
         it "should get all Forum instances binded to the godfather role and the admin user" do
-          subject.with_role(:godfather, admin).should =~ Forum.all.to_a
+          subject.find_as(:godfather, admin).should =~ Forum.all.to_a
         end
 
         it "should get all Forum instances binded to the godfather role and the tourist user" do
-          subject.with_role(:godfather, tourist).should be_empty
+          subject.find_as(:godfather, tourist).should be_empty
         end
 
         it "should get Forum instances binded to the group role and the tourist user" do
-          subject.with_role(:group, tourist).should =~ [ Forum.first ]
+          subject.find_as(:group, tourist).should =~ [ Forum.first ]
         end
 
         it "should not get Forum instances not binded to the group role and the tourist user" do
-          subject.with_role(:group, tourist).should_not include(Forum.last)
+          subject.find_as(:group, tourist).should_not include(Forum.last)
         end
       end
 
@@ -112,11 +112,11 @@ describe Rolify::Resource do
         subject { Group }
 
         it "should get all resources binded to the group role and the admin user" do
-          subject.with_role(:group, admin).should =~ [ Group.last ]
+          subject.find_as(:group, admin).should =~ [ Group.last ]
         end
 
         it "should not get resources not binded to the group role and the admin user" do
-          subject.with_role(:group, admin).should_not include(Group.first)
+          subject.find_as(:group, admin).should_not include(Group.first)
         end
       end
     end
@@ -126,7 +126,7 @@ describe Rolify::Resource do
         subject { Forum }
 
         it "should get Forum instances binded to the forum and group roles and the tourist user" do
-          subject.with_roles([:forum, :group], tourist).should =~ [ Forum.first, Forum.last ]
+          subject.find_as_multiple([:forum, :group], tourist).should =~ [ Forum.first, Forum.last ]
         end
 
       end
@@ -135,7 +135,7 @@ describe Rolify::Resource do
         subject { Group }
 
         it "should get Group instances binded to the group and grouper roles and the admin user" do
-          subject.with_roles([:group, :grouper], admin).should =~ [ Group.first, Group.last ]
+          subject.find_as_multiple([:group, :grouper], admin).should =~ [ Group.first, Group.last ]
         end
 
       end
@@ -145,20 +145,20 @@ describe Rolify::Resource do
       subject { Team }
 
       it "should find Team instance using team_code column" do
-        subject.with_roles([:captain, :player], captain).should =~ [ Team.first, Team.last ]
+        subject.find_as_multiple([:captain, :player], captain).should =~ [ Team.first, Team.last ]
       end
     end
 
     context "with a resource using STI" do
       subject { Organization }
       it "should find instances of children classes" do
-        subject.with_roles(:owner, admin).should =~ [ Company.first ]
+        subject.find_as_multiple(:owner, admin).should =~ [ Company.first ]
       end
     end
   end
 
 
-  describe ".without_roles" do
+  describe ".except_as_multiple" do
     subject { Group }
 
     it { should respond_to(:find_roles).with(1).arguments }
@@ -169,15 +169,15 @@ describe Rolify::Resource do
         subject { Forum }
 
         it "should not include Forum instances with forum role" do
-          subject.without_role(:forum).should_not =~ [ Forum.first, Forum.last ]
+          subject.except_as(:forum).should_not =~ [ Forum.first, Forum.last ]
         end
 
         it "should not include Forum instances with godfather role" do
-          subject.without_role(:godfather).should be_empty
+          subject.except_as(:godfather).should be_empty
         end
 
         it "should be able to modify the resource", :if => ENV['ADAPTER'] == 'active_record' do
-          forum_resource = subject.without_role(:forum).first
+          forum_resource = subject.except_as(:forum).first
           forum_resource.name = "modified name"
           expect { forum_resource.save }.not_to raise_error
         end
@@ -187,7 +187,7 @@ describe Rolify::Resource do
         subject { Group }
 
         it "should not include Group instances with group role" do
-          subject.without_role(:group).should_not =~ [ Group.last ]
+          subject.except_as(:group).should_not =~ [ Group.last ]
         end
       end
 
@@ -198,7 +198,7 @@ describe Rolify::Resource do
         subject { Group }
 
         it "should include Group instances without either the group and grouper roles" do
-          subject.without_roles([:group, :grouper]).should_not =~ [ Group.first, Group.last ]
+          subject.except_as_multiple([:group, :grouper]).should_not =~ [ Group.first, Group.last ]
         end
       end
     end
@@ -208,27 +208,27 @@ describe Rolify::Resource do
         subject { Forum }
 
         it "should get all Forum instances the admin user does not have the forum role" do
-          subject.without_role(:forum, admin).should_not =~ [ Forum.first ]
+          subject.except_as(:forum, admin).should_not =~ [ Forum.first ]
         end
 
         it "should get all Forum instances the tourist user does not have the forum role" do
-          subject.without_role(:forum, tourist).should_not =~ [ Forum.last ]
+          subject.except_as(:forum, tourist).should_not =~ [ Forum.last ]
         end
 
         it "should get all Forum instances the admin user does not have the godfather role" do
-          subject.without_role(:godfather, admin).should_not =~ Forum.all
+          subject.except_as(:godfather, admin).should_not =~ Forum.all
         end
 
         it "should get all Forum instances tourist user does not have the godfather role" do
-          subject.without_role(:godfather, tourist).should =~ Forum.all
+          subject.except_as(:godfather, tourist).should =~ Forum.all
         end
 
         it "should get Forum instances the tourist user does not have the group role" do
-          subject.without_role(:group, tourist).should_not =~ [ Forum.first ]
+          subject.except_as(:group, tourist).should_not =~ [ Forum.first ]
         end
 
         it "should get Forum instances the tourist user does not have the group role" do
-          subject.without_role(:group, tourist).should_not =~ [ Forum.first ]
+          subject.except_as(:group, tourist).should_not =~ [ Forum.first ]
         end
       end
 
@@ -236,11 +236,11 @@ describe Rolify::Resource do
         subject { Group }
 
         it "should get all resources not bounded to the group role and the admin user" do
-          subject.without_role(:group, admin).should =~ [ Group.first ]
+          subject.except_as(:group, admin).should =~ [ Group.first ]
         end
 
         it "should not get resources bound to the group role and the admin user" do
-          subject.without_role(:group, admin).should include(Group.first)
+          subject.except_as(:group, admin).should include(Group.first)
         end
       end
     end
@@ -250,7 +250,7 @@ describe Rolify::Resource do
         subject { Forum }
 
         it "should get Forum instances not bound to the forum and group roles and the tourist user" do
-          subject.without_roles([:forum, :group], tourist).should_not =~ [ Forum.first, Forum.last ]
+          subject.except_as_multiple([:forum, :group], tourist).should_not =~ [ Forum.first, Forum.last ]
         end
 
       end
@@ -259,7 +259,7 @@ describe Rolify::Resource do
         subject { Group }
 
         it "should get Group instances binded to the group and grouper roles and the admin user" do
-          subject.without_roles([:group, :grouper], admin).should =~ [ ]
+          subject.except_as_multiple([:group, :grouper], admin).should =~ [ ]
         end
 
       end
@@ -269,14 +269,14 @@ describe Rolify::Resource do
       subject { Team }
 
       it "should find Team instance not using team_code column" do
-        subject.without_roles(:captain, captain).should =~ [ Team.last ]
+        subject.except_as_multiple(:captain, captain).should =~ [ Team.last ]
       end
     end
 
     context "with a resource using STI" do
       subject { Organization }
       it "should exclude instances of children classes with matching" do
-        subject.without_role(:owner, admin).should_not =~ [ Company.first ]
+        subject.except_as(:owner, admin).should_not =~ [ Company.first ]
       end
     end
   end

--- a/spec/rolify/resource_spec.rb
+++ b/spec/rolify/resource_spec.rb
@@ -27,7 +27,7 @@ describe Rolify::Resource do
   let!(:player_role)     { captain.add_role(:player, Team.last) }
   let!(:company_role)    { admin.add_role(:owner, Company.first) }
 
-  describe ".find_as_multiple" do
+  describe ".find_multiple_as" do
     subject { Group }
 
     it { should respond_to(:find_roles).with(1).arguments }
@@ -74,7 +74,7 @@ describe Rolify::Resource do
         subject { Group }
 
         it "should include Group instances with both group and grouper roles" do
-          subject.find_as_multiple([:group, :grouper]).should =~ [ Group.first, Group.last ]
+          subject.find_multiple_as([:group, :grouper]).should =~ [ Group.first, Group.last ]
         end
       end
     end
@@ -126,7 +126,7 @@ describe Rolify::Resource do
         subject { Forum }
 
         it "should get Forum instances binded to the forum and group roles and the tourist user" do
-          subject.find_as_multiple([:forum, :group], tourist).should =~ [ Forum.first, Forum.last ]
+          subject.find_multiple_as([:forum, :group], tourist).should =~ [ Forum.first, Forum.last ]
         end
 
       end
@@ -135,7 +135,7 @@ describe Rolify::Resource do
         subject { Group }
 
         it "should get Group instances binded to the group and grouper roles and the admin user" do
-          subject.find_as_multiple([:group, :grouper], admin).should =~ [ Group.first, Group.last ]
+          subject.find_multiple_as([:group, :grouper], admin).should =~ [ Group.first, Group.last ]
         end
 
       end
@@ -145,20 +145,20 @@ describe Rolify::Resource do
       subject { Team }
 
       it "should find Team instance using team_code column" do
-        subject.find_as_multiple([:captain, :player], captain).should =~ [ Team.first, Team.last ]
+        subject.find_multiple_as([:captain, :player], captain).should =~ [ Team.first, Team.last ]
       end
     end
 
     context "with a resource using STI" do
       subject { Organization }
       it "should find instances of children classes" do
-        subject.find_as_multiple(:owner, admin).should =~ [ Company.first ]
+        subject.find_multiple_as(:owner, admin).should =~ [ Company.first ]
       end
     end
   end
 
 
-  describe ".except_as_multiple" do
+  describe ".except_multiple_as" do
     subject { Group }
 
     it { should respond_to(:find_roles).with(1).arguments }
@@ -198,7 +198,7 @@ describe Rolify::Resource do
         subject { Group }
 
         it "should include Group instances without either the group and grouper roles" do
-          subject.except_as_multiple([:group, :grouper]).should_not =~ [ Group.first, Group.last ]
+          subject.except_multiple_as([:group, :grouper]).should_not =~ [ Group.first, Group.last ]
         end
       end
     end
@@ -250,7 +250,7 @@ describe Rolify::Resource do
         subject { Forum }
 
         it "should get Forum instances not bound to the forum and group roles and the tourist user" do
-          subject.except_as_multiple([:forum, :group], tourist).should_not =~ [ Forum.first, Forum.last ]
+          subject.except_multiple_as([:forum, :group], tourist).should_not =~ [ Forum.first, Forum.last ]
         end
 
       end
@@ -259,7 +259,7 @@ describe Rolify::Resource do
         subject { Group }
 
         it "should get Group instances binded to the group and grouper roles and the admin user" do
-          subject.except_as_multiple([:group, :grouper], admin).should =~ [ ]
+          subject.except_multiple_as([:group, :grouper], admin).should =~ [ ]
         end
 
       end
@@ -269,7 +269,7 @@ describe Rolify::Resource do
       subject { Team }
 
       it "should find Team instance not using team_code column" do
-        subject.except_as_multiple(:captain, captain).should =~ [ Team.last ]
+        subject.except_multiple_as(:captain, captain).should =~ [ Team.last ]
       end
     end
 


### PR DESCRIPTION
Attempts to fix [266](https://github.com/RolifyCommunity/rolify/issues/266) and [244](https://github.com/RolifyCommunity/rolify/issues/244). 