### PR TITLE
Migration warning Role table does not exist fix.

### DIFF
--- a/lib/rolify/configure.rb
+++ b/lib/rolify/configure.rb
@@ -54,7 +54,6 @@ module Rolify
     def sanity_check(role_cnames)
       return true if ARGV.reduce(nil) { |acc,arg| arg =~ /assets:/ if acc.nil? } == 0
 
-      role_cnames = [ "Role" ] if role_cnames.empty?
       role_cnames.each do |role_cname|
         role_class = role_cname.constantize
         if role_class.superclass.to_s == "ActiveRecord::Base" && role_table_missing?(role_class)


### PR DESCRIPTION
Issue: https://github.com/RolifyCommunity/rolify/issues/329

We call `sanity_check` and pass in an empty array. This throws a warning because we run the sanity check before the migration.

```
    def use_dynamic_shortcuts
      return if !sanity_check([])
      self.dynamic_shortcuts = true
    end
```