### PR TITLE
Make test cases compatible with rspec-rails 3.3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :test do
     gem "sqlite3", :platform => "ruby"
     gem "activerecord", ">= 3.2.0", :require => "active_record"
   when "mongoid"
-    gem "mongoid", ">= 3.1"
+    gem "mongoid", "~> 3.1"
     gem "bson_ext", :platform => "ruby"
   else
     raise "Unknown model adapter: #{ENV["ADAPTER"]}"
@@ -17,6 +17,7 @@ group :test do
   gem 'its'
   gem 'byebug'
   gem 'pry-byebug'
+  gem 'test-unit' # Implicitly loaded by ammeter
   gem 'codeclimate-test-reporter', :require => nil
 end
 

--- a/lib/rolify/matchers.rb
+++ b/lib/rolify/matchers.rb
@@ -5,11 +5,11 @@ RSpec::Matchers.define :have_role do |*args|
     resource.has_role?(*args)
   end
 
-  failure_message_for_should do |resource|
+  failure_message do |resource|
     "expected to have role #{args.map(&:inspect).join(" ")}"
   end
 
-  failure_message_for_should_not do |resource|
+  failure_message_when_negated do |resource|
     "expected not to have role #{args.map(&:inspect).join(" ")}"
   end
 end

--- a/rolify.gemspec
+++ b/rolify.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_development_dependency 'ammeter',     '~> 1.1.2' # Spec generator
+  s.add_development_dependency 'ammeter',     '~> 1.1.3' # Spec generator
   s.add_development_dependency 'bundler',     '>= 1.7.12' # packaging feature
   s.add_development_dependency 'rake',        '~> 10.4.2' # Tasks manager
-  s.add_development_dependency 'rspec-rails', '2.99.0'
+  s.add_development_dependency 'rspec-rails', '3.3.3'
 end

--- a/spec/common_helper.rb
+++ b/spec/common_helper.rb
@@ -1,0 +1,16 @@
+require 'test-unit'
+
+begin
+  require 'pry'
+rescue LoadError
+end
+
+# `Test::Unit::AutoRunner.need_auto_run=` was introduced to the test-unit
+# gem in version 2.4.9. Previous to this version `Test::Unit.run=` was
+# used. The implementation of test-unit included with Ruby has neither
+# method.
+if defined? Test::Unit::AutoRunner
+  Test::Unit::AutoRunner.need_auto_run = false
+elsif defined?(Test::Unit)
+  Test::Unit.run = false
+end

--- a/spec/generators_helper.rb
+++ b/spec/generators_helper.rb
@@ -1,21 +1,27 @@
 require 'rubygems'
 require "bundler/setup"
 
+require 'pry'
+
 require 'rolify'
 require 'rolify/matchers'
-require 'rails'
+require 'rails/all'
 require_relative 'support/stream_helpers'
 include StreamHelpers
 
 require 'coveralls'
 Coveralls.wear_merged!
 
+require 'common_helper'
+
 ENV['ADAPTER'] ||= 'active_record'
 
 if ENV['ADAPTER'] == 'active_record'
   require 'active_record/railtie'
+  ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":memory:")
 else
   require 'mongoid'
+  Mongoid.load!("spec/support/adapters/mongoid.yml", :test)
 end
 
 module TestApp

--- a/spec/rolify/config_spec.rb
+++ b/spec/rolify/config_spec.rb
@@ -161,6 +161,8 @@ describe Rolify do
         config.orm = "mongoid"
       end
     end
+
+    subject { Rolify }
     
     its(:dynamic_shortcuts) { should be_truthy }
     its(:orm) { should eq("mongoid") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,10 +19,7 @@ ENV['ADAPTER'] ||= 'active_record'
 load File.dirname(__FILE__) + "/support/adapters/#{ENV['ADAPTER']}.rb"
 load File.dirname(__FILE__) + '/support/data.rb'
 
-begin
-  require 'pry'
-rescue LoadError
-end
+
 
 def reset_defaults
   Rolify.use_defaults
@@ -46,4 +43,8 @@ def silence_warnings(&block)
   result = block.call
   $VERBOSE = warn_level
   result
+end
+
+RSpec.configure do |config|
+  config.expect_with(:rspec) { |c| c.syntax = [:should, :expect] }
 end

--- a/spec/support/adapters/active_record.rb
+++ b/spec/support/adapters/active_record.rb
@@ -1,6 +1,6 @@
 require 'active_record'
 
-RSpec::Matchers::BuiltIn::OperatorMatcher.register(ActiveRecord::Relation, '=~', RSpec::Matchers::BuiltIn::MatchArray)
+RSpec::Matchers::BuiltIn::OperatorMatcher.register(ActiveRecord::Relation, '=~', RSpec::Matchers::BuiltIn::ContainExactly)
 ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":memory:")
 ActiveRecord::Base.extend Rolify
 


### PR DESCRIPTION
Enables the test suite to use latest stable `rspec-rails` along with latest stable `active_record`. This fixes the failing build on other pull-requests.

This PR does not attempt to resolve the issues with latest version of mongoid, but just restricts the Gemspec to last compatible version. 