### PR TITLE
Don't use quote_column_name for table names

### DIFF
--- a/lib/rolify/adapters/active_record/resource_adapter.rb
+++ b/lib/rolify/adapters/active_record/resource_adapter.rb
@@ -17,16 +17,17 @@ module Rolify
           str << ', ' unless klass == klasses.last
           str
         end
-        resources = relation.joins("INNER JOIN #{quote(roles_table)} ON #{quote(roles_table)}.resource_type IN (#{relations}) AND
-                                    (#{quote(roles_table)}.resource_id IS NULL OR #{quote(roles_table)}.resource_id = #{quote(relation.table_name)}.#{relation.primary_key})")
-        resources = resources.where("#{quote(roles_table)}.name IN (?) AND #{quote(roles_table)}.resource_type IN (?)", Array(role_name), klasses)
-        resources = resources.select("#{quote(relation.table_name)}.*")
+
+        resources = relation.joins("INNER JOIN #{quote_table(roles_table)} ON #{quote_table(roles_table)}.resource_type IN (#{relations}) AND
+                                    (#{quote_table(roles_table)}.resource_id IS NULL OR #{quote_table(roles_table)}.resource_id = #{quote_table(relation.table_name)}.#{quote_column(relation.primary_key)})")
+        resources = resources.where("#{quote_table(roles_table)}.name IN (?) AND #{quote_table(roles_table)}.resource_type IN (?)", Array(role_name), klasses)
+        resources = resources.select("#{quote_table(relation.table_name)}.*")
         resources
       end
 
       def in(relation, user, role_names)
-        roles = user.roles.where(:name => role_names).select("#{quote(role_class.table_name)}.#{role_class.primary_key}")
-        relation.where("#{quote(role_class.table_name)}.#{role_class.primary_key} IN (?) AND ((resource_id = #{quote(relation.table_name)}.#{relation.primary_key}) OR (resource_id IS NULL))", roles)
+        roles = user.roles.where(:name => role_names).select("#{quote_table(role_class.table_name)}.#{quote_column(role_class.primary_key)}")
+        relation.where("#{quote_table(role_class.table_name)}.#{quote_column(role_class.primary_key)} IN (?) AND ((resource_id = #{quote_table(relation.table_name)}.#{quote_column(relation.primary_key)}) OR (resource_id IS NULL))", roles)
       end
 
       def applied_roles(relation, children)
@@ -44,9 +45,14 @@ module Rolify
 
       private
 
-      def quote(column)
+      def quote_column(column)
         ActiveRecord::Base.connection.quote_column_name column
       end
+
+      def quote_table(table)
+        ActiveRecord::Base.connection.quote_table_name table
+      end
+
     end
   end
 end


### PR DESCRIPTION
Fixes Issue #374

Delegates to specific methods from `ActiveRecord::ConnectionAdapters::Quoting` for quoting column names and table names.