### PR TITLE
Update Dynamic module

### DIFF
--- a/lib/rolify.rb
+++ b/lib/rolify.rb
@@ -30,7 +30,6 @@ module Rolify
     has_and_belongs_to_many :roles, rolify_options
 
     self.adapter = Rolify::Adapter::Base.create("role_adapter", self.role_cname, self.name)
-    load_dynamic_methods if Rolify.dynamic_shortcuts
 
     #use strict roles
     self.strict_rolify = true if options[:strict]

--- a/lib/rolify/adapters/active_record/role_adapter.rb
+++ b/lib/rolify/adapters/active_record/role_adapter.rb
@@ -9,6 +9,7 @@ module Rolify
       end
 
       def where_strict(relation, args)
+        return relation.where(:name => args[:name]) if args[:resource].blank?
         resource = if args[:resource].is_a?(Class)
                      {class: args[:resource].to_s, id: nil}
                    else

--- a/lib/rolify/adapters/mongoid/role_adapter.rb
+++ b/lib/rolify/adapters/mongoid/role_adapter.rb
@@ -9,13 +9,14 @@ module Rolify
       end
 
       def where_strict(relation, args)
+        return relation.where(:name => args[:name]) if args[:resource].blank?
         resource = if args[:resource].is_a?(Class)
                      {class: args[:resource].to_s, id: nil}
                    else
                      {class: args[:resource].class.name, id: args[:resource].id}
                    end
 
-          relation.where(:name => args[:name], :resource_type => resource[:class], :resource_id => resource[:id])
+        relation.where(:name => args[:name], :resource_type => resource[:class], :resource_id => resource[:id])
       end
 
       def find_cached(relation, args)

--- a/lib/rolify/dynamic.rb
+++ b/lib/rolify/dynamic.rb
@@ -2,29 +2,15 @@ require "rolify/configure"
 
 module Rolify
   module Dynamic
-    def load_dynamic_methods
-      if ENV['ADAPTER'] == 'active_record'
-        # supported Rails version >= 3.2 with AR should use find_each, since use of .all.each is deprecated
-        self.role_class.group("name, resource_type").includes(:resource).find_each do |r|
-          define_dynamic_method(r.name, r.resource)
-        end
-      else
-        # for compatibility with MongoidDB and older Rails AR - does not support polymorphic includes
-        self.role_class.all.each do |r|
-          define_dynamic_method(r.name, r.resource)
-        end
-      end
-    end
-
     def define_dynamic_method(role_name, resource)
       class_eval do 
         define_method("is_#{role_name}?".to_sym) do
           has_role?("#{role_name}")
-        end if !method_defined?("is_#{role_name}?".to_sym)
+        end if !method_defined?("is_#{role_name}?".to_sym) && self.adapter.where_strict(self.role_class, name: role_name).exists?
 
         define_method("is_#{role_name}_of?".to_sym) do |arg|
           has_role?("#{role_name}", arg)
-        end if !method_defined?("is_#{role_name}_of?".to_sym) && resource
+        end if !method_defined?("is_#{role_name}_of?".to_sym) && resource && self.adapter.where_strict(self.role_class, name: role_name, resource: resource).exists?
       end
     end
   end

--- a/lib/rolify/role.rb
+++ b/lib/rolify/role.rb
@@ -94,7 +94,7 @@ module Rolify
         resource = args.first
         self.class.define_dynamic_method $1, resource
         return has_role?("#{$1}", resource)
-      end unless !Rolify.dynamic_shortcuts
+      end if Rolify.dynamic_shortcuts
       super
     end
 


### PR DESCRIPTION
I propose to remove the `load_dynamic_methods` method from the `Dynamic` module, because it loads all the roles at once from the table. This is a bad way. Instead, it's better to define shortcut methods in the time of the call of `method_missing` if they exist in the `Role` table.

This will solve the problem of greedy load all the roles when the rails app is initialized