### PR TITLE
Fix regression in generator around belongs_to options compatibility

### DIFF
--- a/lib/generators/active_record/rolify_generator.rb
+++ b/lib/generators/active_record/rolify_generator.rb
@@ -1,5 +1,6 @@
 require 'rails/generators/active_record'
 require 'active_support/core_ext'
+require 'erb'
 
 module ActiveRecord
   module Generators
@@ -56,20 +57,7 @@ module ActiveRecord
       end
 
       def model_content
-        content = <<RUBY
-  has_and_belongs_to_many :%{user_cname}, :join_table => :%{join_table}
-
-  belongs_to :resource,
-             :polymorphic => true,
-             :optional => true
-
-  validates :resource_type,
-            :inclusion => { :in => Rolify.resource_types },
-            :allow_nil => true
-
-  scopify
-RUBY
-        content % { :user_cname => user_class.table_name, :join_table => "#{user_cname.constantize.table_name}_#{table_name}"}
+        ERB.new(File.read(File.join(__dir__, 'templates/model.rb'))).result(binding)
       end
 
       def user_class

--- a/lib/generators/active_record/templates/model.rb
+++ b/lib/generators/active_record/templates/model.rb
@@ -1,0 +1,16 @@
+has_and_belongs_to_many :<%= user_class.table_name %>, :join_table => :<%= join_table %>
+
+<% if Rails::VERSION::MAJOR < 5 %>
+belongs_to :resource,
+           :polymorphic => true
+<% else %>
+belongs_to :resource,
+           :polymorphic => true,
+           :optional => true
+<% end %>
+
+validates :resource_type,
+          :inclusion => { :in => Rolify.resource_types },
+          :allow_nil => true
+
+scopify

--- a/spec/generators/rolify/rolify_activerecord_generator_spec.rb
+++ b/spec/generators/rolify/rolify_activerecord_generator_spec.rb
@@ -45,6 +45,16 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
       it { should exist }
       it { should contain "class Role < ActiveRecord::Base" }
       it { should contain "has_and_belongs_to_many :users, :join_table => :users_roles" }
+      it do
+        if Rails::VERSION::MAJOR < 5
+          should contain "belongs_to :resource,\n"
+                          "           :polymorphic => true"
+        else
+          should contain "belongs_to :resource,\n"
+                          "           :polymorphic => true,\n"
+                          "           :optional => true"
+        end
+      end
       it { should contain "belongs_to :resource,\n"
                           "           :polymorphic => true,\n"
                           "           :optional => true"


### PR DESCRIPTION
Fixes https://github.com/RolifyCommunity/rolify/issues/392 

As mentioned by @NerdDiffer in https://github.com/RolifyCommunity/rolify/commit/a417a42e06eff8f860eee9dec48371b70a5a43b9#commitcomment-16775070 usage of  `:optional => true` introduces an ArgumentError in Rails < 5. 

This was not caught in our specs, because the generator specs do not actually execute the generated files. While I intend to improve the generator specs to handle such errors in a future PR, this one attends to the regression at hand.