### PR TITLE
Update initializer.rb to include the remove_role_if_empty option and …

### DIFF
--- a/lib/generators/rolify/templates/initializer.rb
+++ b/lib/generators/rolify/templates/initializer.rb
@@ -4,4 +4,7 @@ Rolify.configure<%= "(\"#{class_name.camelize.to_s}\")" if class_name != "Role" 
 
   # Dynamic shortcuts for User class (user.is_admin? like methods). Default is: false
   # config.use_dynamic_shortcuts
+  
+  # Configuration to remove roles from database once the last resource is removed. Default is: true
+  # config.remove_role_if_empty = false
 end


### PR DESCRIPTION
…description

The default action is to remove roles if the last resource is removed. Important to disable this if the roles are associated with permissions (Pundit etc.) and cascades are enabled.

I'd suggest changing the default action, but in absence of that, a small change to the initializer to include the option and description to change it.