### PR TITLE
Allow inverse_of option on rolify method

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ The `rolify` method accepts the following callback options:
 
 Mongoid callbacks are also supported and works the same way.
 
+The `rolify` method also accepts the `inverse_of` option if you need to disambiguate the relationship.
+
 ### 3.2 Configure your resource models
 
 In the resource models you want to apply roles on, just add ``resourcify`` method.

--- a/lib/rolify.rb
+++ b/lib/rolify.rb
@@ -25,7 +25,7 @@ module Rolify
 
     rolify_options = { :class_name => options[:role_cname].camelize }
     rolify_options.merge!({ :join_table => self.role_join_table_name }) if Rolify.orm == "active_record"
-    rolify_options.merge!(options.reject{ |k,v| ![ :before_add, :after_add, :before_remove, :after_remove ].include? k.to_sym })
+    rolify_options.merge!(options.reject{ |k,v| ![ :before_add, :after_add, :before_remove, :after_remove, :inverse_of ].include? k.to_sym })
 
     has_and_belongs_to_many :roles, rolify_options
 


### PR DESCRIPTION
We use mongoid and have multiple associations to our users model from role. Therefore, we need to be able to specify the `inverse_of` on `Users.roles`.

For example, we get the following error:
```
Mongoid::Errors::AmbiguousRelationship:

message:
    Ambiguous relations :creator, :updater, :users defined on Role.
  summary:
    When Mongoid attempts to set an inverse document of a relation in memory, it needs to know which relation it belongs to. When setting :roles, Mongoid looked on the class User for a matching relation, but multiples were found that could potentially match: :creator, :updater, :users.
  resolution:
    On the :roles relation on User you must add an :inverse_of option to specify the exact relationship on Role that is the opposite of :roles.
```

Thoughts on how to add a spec for this? They're currently failing on master so I didn't spend a lot of time trying.