### PR TITLE
ActiveRecord and Mongoid adapters now acceps nil for role_name on remove

### DIFF
--- a/lib/rolify/adapters/active_record/role_adapter.rb
+++ b/lib/rolify/adapters/active_record/role_adapter.rb
@@ -50,7 +50,8 @@ module Rolify
       end
 
       def remove(relation, role_name, resource = nil)
-        cond = { :name => role_name }
+        cond = {}
+        cond[:name] = role_name unless role_name.blank?
         cond[:resource_type] = (resource.is_a?(Class) ? resource.to_s : resource.class.name) if resource
         cond[:resource_id] = resource.id if resource && !resource.is_a?(Class)
         roles = relation.roles.where(cond)

--- a/lib/rolify/adapters/mongoid/role_adapter.rb
+++ b/lib/rolify/adapters/mongoid/role_adapter.rb
@@ -66,7 +66,8 @@ module Rolify
         #
         #  role.destroy if role.send(user_class.to_s.tableize.to_sym).empty?
         #end
-        cond = { :name => role_name }
+        cond = {}
+        cond[:name] = role_name unless role_name.blank?
         cond[:resource_type] = (resource.is_a?(Class) ? resource.to_s : resource.class.name) if resource
         cond[:resource_id] = resource.id if resource && !resource.is_a?(Class)
         roles = relation.roles.where(cond)


### PR DESCRIPTION
This is my solution for https://github.com/RolifyCommunity/rolify/issues/426

Use case: I want to remove all the roles a user has for some resource, without listing them individually.

Basically this allows for syntax ```current_user.remove_role nil, some_resource```.
