### PR TITLE
active_record/role_adapter.rb improvements

### DIFF
--- a/lib/rolify/adapters/active_record/role_adapter.rb
+++ b/lib/rolify/adapters/active_record/role_adapter.rb
@@ -46,7 +46,7 @@ module Rolify
       end
 
       def add(relation, role)
-        relation.role_ids |= [role.id]
+        relation.roles << role
       end
 
       def remove(relation, role_name, resource = nil)


### PR DESCRIPTION
relation.role_ids |= [role.id] works extremely slow when 10000 roles attached. It is take about 2 minutes to add role. So this fix make it work as expected - about some ms. All tests passed.