### PR TITLE
Improved optional flag compability detection

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -2,7 +2,7 @@ class RolifyCreate<%= table_name.camelize %> < ActiveRecord::Migration
   def change
     create_table(:<%= table_name %>) do |t|
       t.string :name
-      t.references :resource, :polymorphic => true
+      t.references :resource, polymorphic: true
 
       t.timestamps
     end

--- a/lib/generators/active_record/templates/model.rb
+++ b/lib/generators/active_record/templates/model.rb
@@ -1,16 +1,11 @@
-has_and_belongs_to_many :<%= user_class.table_name %>, :join_table => :<%= join_table %>
+has_and_belongs_to_many :<%= user_class.table_name %>, join_table: :<%= join_table %>
 
-<% if Rails::VERSION::MAJOR < 5 %>
-belongs_to :resource,
-           :polymorphic => true
+<% if Rails::VERSION::MAJOR >= 5 %>
+  belongs_to :resource, polymorphic: true, optional: true
 <% else %>
-belongs_to :resource,
-           :polymorphic => true,
-           :optional => true
+  belongs_to :resource, polymorphic: true,
 <% end %>
 
-validates :resource_type,
-          :inclusion => { :in => Rolify.resource_types },
-          :allow_nil => true
+validates :resource_type, inclusion: { in: Rolify.resource_types }, allow_nil: true
 
 scopify

--- a/spec/generators/rolify/rolify_activerecord_generator_spec.rb
+++ b/spec/generators/rolify/rolify_activerecord_generator_spec.rb
@@ -44,30 +44,22 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
       subject { file('app/models/role.rb') }
       it { should exist }
       it do
-        if Rails::VERSION::MAJOR < 5
-          should contain "class Role < ActiveRecord::Base"
-        else
+        if Rails::VERSION::MAJOR >= 5
           should contain "class Role < ApplicationRecord"
-        end
-      end
-      it { should contain "has_and_belongs_to_many :users, :join_table => :users_roles" }
-      it do
-        if Rails::VERSION::MAJOR < 5
-          should contain "belongs_to :resource,\n"
-                          "           :polymorphic => true"
         else
-          should contain "belongs_to :resource,\n"
-                          "           :polymorphic => true,\n"
-                          "           :optional => true"
+          should contain "class Role < ActiveRecord::Base"
         end
       end
-      it { should contain "belongs_to :resource,\n"
-                          "           :polymorphic => true,\n"
-                          "           :optional => true"
-      }
-      it { should contain "validates :resource_type,\n"
-                          "          :inclusion => { :in => Rolify.resource_types },\n"
-                          "          :allow_nil => true" }
+      it { should contain "has_and_belongs_to_many :users, join_table: :users_roles" }
+      it do
+        if Rails::VERSION::MAJOR >= 5
+          should contain "belongs_to :resource, polymorphic: true, optional: true"
+        else
+          should contain "belongs_to :resource, polymorphic: true"
+        end
+      end
+      it { should contain "belongs_to :resource, polymorphic: true" }
+      it { should contain "validates :resource_type, inclusion: { in: Rolify.resource_types }, allow_nil: true" }
     end
 
     describe 'app/models/user.rb' do
@@ -117,10 +109,8 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
           should contain "class AdminRole < ApplicationRecord"
         end
       end
-      it { should contain "has_and_belongs_to_many :admin_users, :join_table => :admin_users_admin_roles" }
-      it { should contain "belongs_to :resource,\n"
-                          "           :polymorphic => true,\n"
-                          "           :optional => true"
+      it { should contain "has_and_belongs_to_many :admin_users, join_table: :admin_users_admin_roles" }
+      it { should contain "belongs_to :resource, polymorphic: true"
       }
     end
 
@@ -178,11 +168,8 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
           should contain "class Admin::Role < ApplicationRecord"
         end
       end
-      it { should contain "has_and_belongs_to_many :admin_users, :join_table => :admin_users_admin_roles" }
-      it { should contain "belongs_to :resource,\n"
-                          "           :polymorphic => true,\n"
-                          "           :optional => true"
-      }
+      it { should contain "has_and_belongs_to_many :admin_users, join_table: :admin_users_admin_roles" }
+      it { should contain "belongs_to :resource, polymorphic: true" }
     end
 
     describe 'app/models/admin/user.rb' do


### PR DESCRIPTION
Optional flag comes with Rails 5 because new version of Rails require presence by default, so we need to use it in rails version >= 5.
 