### PR TITLE
fixed ambiguous column error

### DIFF
--- a/lib/rolify/adapters/active_record/resource_adapter.rb
+++ b/lib/rolify/adapters/active_record/resource_adapter.rb
@@ -27,7 +27,7 @@ module Rolify
 
       def in(relation, user, role_names)
         roles = user.roles.where(:name => role_names).select("#{quote_table(role_class.table_name)}.#{quote_column(role_class.primary_key)}")
-        relation.where("#{quote_table(role_class.table_name)}.#{quote_column(role_class.primary_key)} IN (?) AND ((resource_id = #{quote_table(relation.table_name)}.#{quote_column(relation.primary_key)}) OR (resource_id IS NULL))", roles)
+        relation.where("#{quote_table(role_class.table_name)}.#{quote_column(role_class.primary_key)} IN (?) AND ((#{quote_table(role_class.table_name)}.resource_id = #{quote_table(relation.table_name)}.#{quote_column(relation.primary_key)}) OR (#{quote_table(role_class.table_name)}.resource_id IS NULL))", roles)
       end
 
       def applied_roles(relation, children)


### PR DESCRIPTION
i've tried to join roles table twice (but with another join condition) and received an error `ActiveRecord::StatementInvalid: PG::AmbiguousColumn: ERROR:  column reference "resource_id" is ambiguous` 
So here is a patch which fixes it.
