### PR TITLE
Add only with role finder

### DIFF
--- a/lib/rolify/finders.rb
+++ b/lib/rolify/finders.rb
@@ -8,6 +8,10 @@ module Rolify
       self.adapter.all_except(self, self.with_role(role_name, resource))
     end
 
+    def only_with_role(role_name, resource = nil)
+      with_role(role_name, resource).select { |record| record.roles.count == 1 }
+    end
+
     def with_all_roles(*args)
       users = []
       parse_args(args, users) do |users_to_add|
@@ -26,9 +30,9 @@ module Rolify
       users.uniq
     end
   end
-  
+
   private
-  
+
   def parse_args(args, users, &block)
     args.each do |arg|
       if arg.is_a? Hash

--- a/spec/rolify/shared_examples/shared_examples_for_finders.rb
+++ b/spec/rolify/shared_examples/shared_examples_for_finders.rb
@@ -97,7 +97,55 @@ shared_examples_for :finders do |param_name, param_method|
         end
       end
     end
-    
+
+    describe ".only_with_role" do
+      it { should respond_to(:only_with_role).with(1).argument }
+      it { should respond_to(:only_with_role).with(2).arguments }
+
+      context "with a global role" do
+        it { subject.only_with_role("admin".send(param_method)).should be_empty }
+        it { subject.only_with_role("moderator".send(param_method)).should be_empty }
+        it { subject.only_with_role("visitor".send(param_method)).should be_empty }
+      end
+
+      context "with a class scoped role" do
+        context "on Forum class" do
+          it { subject.only_with_role("admin".send(param_method), Forum).should be_empty }
+          it { subject.only_with_role("moderator".send(param_method), Forum).should be_empty }
+          it { subject.only_with_role("visitor".send(param_method), Forum).should be_empty }
+        end
+
+        context "on Group class" do
+          it { subject.only_with_role("admin".send(param_method), Group).should be_empty }
+          it { subject.only_with_role("moderator".send(param_method), Group).should be_empty }
+          it { subject.only_with_role("visitor".send(param_method), Group).should be_empty }
+        end
+      end
+
+      context "with an instance scoped role" do
+        context "on Forum.first instance" do
+          it { subject.only_with_role("admin".send(param_method), Forum.first).should be_empty }
+          it { subject.only_with_role("moderator".send(param_method), Forum.first).should be_empty }
+          it { subject.only_with_role("visitor".send(param_method), Forum.first).should be_empty }
+        end
+
+        context "on Forum.last instance" do
+          it { subject.only_with_role("admin".send(param_method), Forum.last).should be_empty }
+          it { subject.only_with_role("moderator".send(param_method), Forum.last).should be_empty }
+          it { subject.only_with_role("visitor".send(param_method), Forum.last).should eq[visitor] } # =~ doesn't pass using mongoid, don't know why...
+        end
+
+        context "on Group.first instance" do
+          it { subject.only_with_role("admin".send(param_method), Group.first).should be_empty }
+          it { subject.only_with_role("moderator".send(param_method), Group.first).should be_empty }
+          it { subject.only_with_role("visitor".send(param_method), Group.first).should be_empty }
+        end
+
+        context "on Company.first_instance" do
+          it { subject.only_with_role("owner".send(param_method), Company.first).should be_empty }
+        end
+      end
+    end
 
     describe ".with_all_roles" do
       it { should respond_to(:with_all_roles) }


### PR DESCRIPTION
Add feature according to https://github.com/RolifyCommunity/rolify/issues/424 issue.

Changes:
as the `only_has_role?` is already defined add `only_with_role` finder and specs for it.