### PR TITLE
Add ActiveRecord version to migration

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -1,4 +1,4 @@
-class RolifyCreate<%= table_name.camelize %> < ActiveRecord::Migration
+class RolifyCreate<%= table_name.camelize %> < ActiveRecord::Migration[<%= ActiveRecord.version.to_s.to_f %>]
   def change
     create_table(:<%= table_name %>) do |t|
       t.string :name


### PR DESCRIPTION
Fixes #444 

I did test this fix by running the generator in a Rails app I have going and it worked, but I did not write any rspec tests because I could not get the suite to run at all. I tried the instructions in `spec/README.rdoc` as well as everything else I could think of to get the tests to run but kept getting these "errors occurred outside of examples" messages:
```
Failure/Error: require 'active_record'

LoadError:
  cannot load such file -- active_record
# ./spec/support/adapters/utils/active_record.rb:1:in `require'
```
I definitely have ActiveRecord installed, so I don't know what's going on. If anyone has insight on this, I'd be glad to write some specs for this new behavior if I can get the suite to actually run.