### PR TITLE
Update migration template for rails 5

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -1,4 +1,4 @@
-class RolifyCreate<%= table_name.camelize %> < ActiveRecord::Migration
+class RolifyCreate<%= table_name.camelize %> < ActiveRecord::Migration[5.1]
   def change
     create_table(:<%= table_name %>) do |t|
       t.string :name


### PR DESCRIPTION
 Directly inheriting from ActiveRecord::Migration is not supported for rails 5.