### PR TITLE
fix migration generator for AR 5.x

### DIFF
--- a/lib/generators/active_record/rolify_generator.rb
+++ b/lib/generators/active_record/rolify_generator.rb
@@ -35,7 +35,7 @@ module ActiveRecord
       end
 
       def copy_rolify_migration
-        migration_template "migration.rb", "db/migrate/rolify_create_#{table_name}.rb"
+        migration_template "migration.rb", "db/migrate/rolify_create_#{table_name}.rb", migration_version: migration_version
       end
 
       private
@@ -80,6 +80,16 @@ module ActiveRecord
 Rolify expected a model named #{user_cname} to be defined but could not find one.
 Please ensure that this model exists and is not mis-spelled and re-run the generator.
 MSG
+      end
+
+      def rails5?
+        Rails.version.start_with? '5'
+      end
+
+      def migration_version
+        if rails5?
+          "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+        end
       end
 
     end

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -1,4 +1,4 @@
-class RolifyCreate<%= table_name.camelize %> < ActiveRecord::Migration
+class RolifyCreate<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table(:<%= table_name %>) do |t|
       t.string :name


### PR DESCRIPTION
fix for
```
❯ rake db:migrate
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class RolifyCreateRoles < ActiveRecord::Migration[4.2]
```