### PR TITLE
remove a separate index for the name column

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -12,7 +12,6 @@ class RolifyCreate<%= table_name.camelize %> < ActiveRecord::Migration
       t.references :<%= role_reference %>
     end
 
-    add_index(:<%= table_name %>, :name)
     add_index(:<%= table_name %>, [ :name, :resource_type, :resource_id ])
     add_index(:<%= join_table %>, [ :<%= user_reference %>_id, :<%= role_reference %>_id ])
   end

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -11,7 +11,7 @@ class RolifyCreate<%= table_name.camelize %> < ActiveRecord::Migration
       t.references :<%= user_reference %>
       t.references :<%= role_reference %>
     end
-
+    <% if ActiveRecord::Base.connection.class.to_s.demodulize != 'PostgreSQLAdapter' %><%= "\n    " %>add_index(:<%= table_name %>, :name)<% end %>
     add_index(:<%= table_name %>, [ :name, :resource_type, :resource_id ])
     add_index(:<%= join_table %>, [ :<%= user_reference %>_id, :<%= role_reference %>_id ])
   end

--- a/spec/generators/rolify/rolify_activerecord_generator_spec.rb
+++ b/spec/generators/rolify/rolify_activerecord_generator_spec.rb
@@ -8,6 +8,7 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
   destination File.expand_path("../../../../tmp", __FILE__)
   teardown :cleanup_destination_root
 
+  let(:adapter) { 'SQLite3Adapter' }
   before {
     prepare_destination
   }
@@ -20,6 +21,8 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
     before(:all) { arguments %w(Role) }
 
     before {
+      allow(ActiveRecord::Base).to receive_message_chain(
+        'connection.class.to_s.demodulize') { adapter }
       capture(:stdout) {
         generator.create_file "app/models/user.rb" do
           <<-RUBY
@@ -81,6 +84,24 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
       it { should be_a_migration }
       it { should contain "create_table(:roles) do" }
       it { should contain "create_table(:users_roles, :id => false) do" }
+
+      context 'mysql2' do
+        let(:adapter) { 'Mysql2Adapter' }
+
+        it { expect(subject).to contain('add_index(:roles, :name)') }
+      end
+
+      context 'sqlite3' do
+        let(:adapter) { 'SQLite3Adapter' }
+
+        it { expect(subject).to contain('add_index(:roles, :name)') }
+      end
+
+      context 'pg' do
+        let(:adapter) { 'PostgreSQLAdapter' }
+
+        it { expect(subject).not_to contain('add_index(:roles, :name)') }
+      end
     end
   end
 
@@ -88,6 +109,8 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
     before(:all) { arguments %w(AdminRole AdminUser) }
 
     before {
+      allow(ActiveRecord::Base).to receive_message_chain(
+        'connection.class.to_s.demodulize') { adapter }
       capture(:stdout) {
         generator.create_file "app/models/admin_user.rb" do
           "class AdminUser < ActiveRecord::Base\nend"
@@ -136,6 +159,24 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
       it { should be_a_migration }
       it { should contain "create_table(:admin_roles)" }
       it { should contain "create_table(:admin_users_admin_roles, :id => false) do" }
+
+      context 'mysql2' do
+        let(:adapter) { 'Mysql2Adapter' }
+
+        it { expect(subject).to contain('add_index(:admin_roles, :name)') }
+      end
+
+      context 'sqlite3' do
+        let(:adapter) { 'SQLite3Adapter' }
+
+        it { expect(subject).to contain('add_index(:admin_roles, :name)') }
+      end
+
+      context 'pg' do
+        let(:adapter) { 'PostgreSQLAdapter' }
+
+        it { expect(subject).not_to contain('add_index(:admin_roles, :name)') }
+      end
     end
   end
 
@@ -143,6 +184,8 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
     before(:all) { arguments %w(Admin::Role Admin::User) }
 
     before {
+      allow(ActiveRecord::Base).to receive_message_chain(
+        'connection.class.to_s.demodulize') { adapter }
       capture(:stdout) {
         generator.create_file "app/models/admin/user.rb" do
           <<-RUBY
@@ -197,6 +240,24 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
       it { should be_a_migration }
       it { should contain "create_table(:admin_roles)" }
       it { should contain "create_table(:admin_users_admin_roles, :id => false) do" }
+
+      context 'mysql2' do
+        let(:adapter) { 'Mysql2Adapter' }
+
+        it { expect(subject).to contain('add_index(:admin_roles, :name)') }
+      end
+
+      context 'sqlite3' do
+        let(:adapter) { 'SQLite3Adapter' }
+
+        it { expect(subject).to contain('add_index(:admin_roles, :name)') }
+      end
+
+      context 'pg' do
+        let(:adapter) { 'PostgreSQLAdapter' }
+
+        it { expect(subject).not_to contain('add_index(:admin_roles, :name)') }
+      end
     end
   end
 end


### PR DESCRIPTION
**Note:** I tested with Postgres only. Run an `EXPLAIN` query:  
```
> Role.where(name: 'Admin').explain
  Role Load (0.5ms)  SELECT "roles".* FROM "roles" WHERE "roles"."name" = $1  [["name", "Admin"]]
 => EXPLAIN for: SELECT "roles".* FROM "roles" WHERE "roles"."name" = $1 [["name", "Admin"]]
                                                     QUERY PLAN
--------------------------------------------------------------------------------------------------------------------
 Bitmap Heap Scan on roles  (cost=4.17..11.28 rows=3 width=96)
   Recheck Cond: ((name)::text = 'Admin'::text)
   ->  Bitmap Index Scan on index_roles_on_name_and_resource_type_and_resource_id  (cost=0.00..4.17 rows=3 width=0)
         Index Cond: ((name)::text = 'Admin'::text)
(4 rows)
```

https://github.com/ankane/pghero adds this index to the Duplicate Indexes section.

On roles  
`index_roles_on_name (name)`  
is covered by  
`index_roles_on_name_and_resource_type_and_resource_id (name, resource_type, resource_id)`