### PR TITLE
Make it safe to call Thing.with_role(:admin, user) even if user is not persisted

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'bundler'
 require 'rspec/core/rake_task'
 require 'coveralls/rake/task'
+require 'appraisal'
 
 Bundler::GemHelper.install_tasks
 

--- a/lib/rolify/adapters/active_record/resource_adapter.rb
+++ b/lib/rolify/adapters/active_record/resource_adapter.rb
@@ -26,7 +26,7 @@ module Rolify
       end
 
       def in(relation, user, role_names)
-        roles = user.roles.where(:name => role_names).select("#{quote_table(role_class.table_name)}.#{quote_column(role_class.primary_key)}")
+        roles = user.roles.where(:name => role_names).select("#{quote_table(role_class.table_name)}.#{quote_column(role_class.primary_key)}").to_a
         relation.where("#{quote_table(role_class.table_name)}.#{quote_column(role_class.primary_key)} IN (?) AND ((#{quote_table(role_class.table_name)}.resource_id = #{quote_table(relation.table_name)}.#{quote_column(relation.primary_key)}) OR (#{quote_table(role_class.table_name)}.resource_id IS NULL))", roles)
       end
 


### PR DESCRIPTION
This will return an empty result now (like it used to) instead of raising an exception.

Fixes #382
