### PR TITLE
Maintain compatibility with 1.9.3

### DIFF
--- a/lib/generators/active_record/rolify_generator.rb
+++ b/lib/generators/active_record/rolify_generator.rb
@@ -57,6 +57,9 @@ module ActiveRecord
       end
 
       def model_content
+        if RUBY_VERSION == "1.9.3"
+          __dir__ = File.expand_path('..', __FILE__)
+        end
         ERB.new(File.read(File.join(__dir__, 'templates/model.rb'))).result(binding)
       end
 

--- a/lib/generators/active_record/rolify_generator.rb
+++ b/lib/generators/active_record/rolify_generator.rb
@@ -57,7 +57,7 @@ module ActiveRecord
       end
 
       def model_content
-        if RUBY_VERSION == "1.9.3"
+        unless defined? __dir__
           __dir__ = File.expand_path('..', __FILE__)
         end
         ERB.new(File.read(File.join(__dir__, 'templates/model.rb'))).result(binding)


### PR DESCRIPTION
Hi,

I had an issue with the generator my Rails v3.2, ruby 1.9.3 application. It seems `__dir__` is not defined in 1.9.3.

```
$ rails g rolify Role Login
      invoke  active_record
      create    app/models/role.rb
      invoke    rspec
      create      spec/models/role_spec.rb
/Users/mq20170527/.rvm/gems/ruby-1.9.3-p551/gems/rolify-5.2.0/lib/generators/active_record/rolify_generator.rb:60:in `model_content': undefined local variable or method `__dir__' for #<ActiveRecord::Generators::RolifyGenerator:0x007fefd058d230> (NameError)
	from /Users/mq20170527/.rvm/gems/ruby-1.9.3-p551/gems/rolify-5.2.0/lib/generators/active_record/rolify_generator.rb:34:in `inject_role_class'
```

This fixes the problem.