### PR TITLE
CI: Use 2.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 
 before_install:
   - gem update --system
@@ -14,7 +13,7 @@ after_success:
 rvm:
   - 2.6.2
   - 2.5.5
-  - 2.4.5
+  - 2.4.6
   - 2.3.8
 
 gemfile:


### PR DESCRIPTION
This PR updates the CI matrix to use latest 2.4.

Also:

- Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration