### PR TITLE
CI: Use 2.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ after_success:
   - bundle exec codeclimate-test-reporter
 
 rvm:
-  - 2.6.2
+  - 2.6.3
   - 2.5.5
   - 2.4.6
   - 2.3.8


### PR DESCRIPTION
This PR updates latest Ruby in the CI matrix to its latest release.