### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/rolify.gemspec
+++ b/rolify.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.version     = Rolify::VERSION
   s.platform    = Gem::Platform::RUBY
   s.homepage    = 'https://github.com/RolifyCommunity/rolify'
-  s.rubyforge_project = s.name
 
   s.license     = 'MIT'
 


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.