### PR TITLE
Fix deprecation warnings in Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ after_success:
   - bundle exec codeclimate-test-reporter
 
 rvm:
+  - 2.7.0
   - 2.6.3
   - 2.5.5
   - 2.4.6

--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,7 @@
 appraise 'mongoid-5' do
   gem "mongoid", "~> 5"
   gem "bson_ext", "1.5.1"
+  gem 'bigdecimal', '1.4.2'
 end
 
 appraise 'mongoid-6' do
@@ -17,6 +18,7 @@ end
 appraise 'activerecord-4' do
   gem "sqlite3", "~> 1.3.6"
   gem "activerecord", "~> 4.2.11", :require => "active_record"
+  gem 'bigdecimal', '1.4.2'
 end
 
 appraise 'activerecord-5' do

--- a/gemfiles/activerecord_4.gemfile
+++ b/gemfiles/activerecord_4.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.3.6"
 gem "activerecord", "~> 4.2.11", require: "active_record"
+gem "bigdecimal", "1.4.2"
 
 group :test do
   gem "appraisal"

--- a/gemfiles/mongoid_5.gemfile
+++ b/gemfiles/mongoid_5.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "mongoid", "~> 5"
 gem "bson_ext", "1.5.1"
+gem "bigdecimal", "1.4.2"
 
 group :test do
   gem "appraisal"

--- a/lib/rolify.rb
+++ b/lib/rolify.rb
@@ -27,7 +27,7 @@ module Rolify
     rolify_options.merge!({ :join_table => self.role_join_table_name }) if Rolify.orm == "active_record"
     rolify_options.merge!(options.reject{ |k,v| ![ :before_add, :after_add, :before_remove, :after_remove, :inverse_of ].include? k.to_sym })
 
-    has_and_belongs_to_many :roles, rolify_options
+    has_and_belongs_to_many :roles, **rolify_options
 
     self.adapter = Rolify::Adapter::Base.create("role_adapter", self.role_cname, self.name)
 
@@ -48,7 +48,7 @@ module Rolify
     self.role_cname = options[:role_cname]
     self.role_table_name = self.role_cname.tableize.gsub(/\//, "_")
 
-    has_many association_name, resourcify_options
+    has_many association_name, **resourcify_options
 
     self.resource_adapter = Rolify::Adapter::Base.create("resource_adapter", self.role_cname, self.name)
     @@resource_types << self.name


### PR DESCRIPTION
I was getting `undefined method `new' for BigDecimal:Class` errors after upgrading to 2.7 which is why I pinned the bigdecimal versions for older versions of activesupport

I'm new to testing across multiple gemfiles + ruby versions and welcome any feedback on whether or not this is the right way to do it