### PR TITLE
Add Ruby 3.1 and ActiveRecord 7 to CI

### DIFF
--- a/.github/workflows/activerecord.yml
+++ b/.github/workflows/activerecord.yml
@@ -8,6 +8,13 @@ jobs:
       matrix:
         gemfile: [activerecord_4, activerecord_5, activerecord_6]
         ruby: [2.5.7, 2.6.5, 2.7.2]
+        include:
+          - gemfile: activerecord_7
+            ruby: '3.1'
+          - gemfile: activerecord_7
+            ruby: '3.0'
+          - gemfile: activerecord_6
+            ruby: '3.0'
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
       ADAPTER: active_record

--- a/gemfiles/activerecord_7.gemfile
+++ b/gemfiles/activerecord_7.gemfile
@@ -3,10 +3,10 @@
 source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.4", platform: "ruby"
-gem "activerecord", "~> 6.1.0", require: "active_record"
-gem "actionpack", "~> 6.1.0"
-gem "activemodel", "~> 6.1.0"
-gem "railties", "~> 6.1.0"
+gem "activerecord", "~> 7.0.0", require: "active_record"
+gem "actionpack", "~> 7.0.0"
+gem "activemodel", "~> 7.0.0"
+gem "railties", "~> 7.0.0"
 
 group :test do
   gem "codeclimate-test-reporter", require: nil

--- a/spec/generators/rolify/rolify_activerecord_generator_spec.rb
+++ b/spec/generators/rolify/rolify_activerecord_generator_spec.rb
@@ -32,7 +32,11 @@ describe Rolify::Generators::RolifyGenerator, :if => ENV['ADAPTER'] == 'active_r
         end
       }
       require File.join(destination_root, "app/models/user.rb")
-      run_generator
+      if Rails::VERSION::MAJOR >= 7
+        run_generator %w(--skip-collision-check)
+      else
+        run_generator
+      end
     }
 
     describe 'config/initializers/rolify.rb' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require "simplecov"
-SimpleCov.start
+require 'coveralls'
+Coveralls.wear_merged!
 
 require 'rubygems'
 require "bundler/setup"
@@ -12,9 +12,6 @@ begin
 rescue LoadError
 end
 require 'database_cleaner'
-
-require 'coveralls'
-Coveralls.wear_merged!
 
 ENV['ADAPTER'] ||= 'active_record'
 


### PR DESCRIPTION
In addition to the changes to the CI configuration this PR includes changes to:

* Add Gemfile for ActiveRecord 7 and update the ActiveRecord 6 gemfile to restrict to 6.1
* Address collision problem when using ActiveRecord 7 and the default class name 'Role'
* Use Coveralls wear_merged! and move to the top of the spec file, eliminating the SimpleCov.start call.