### PR TITLE
Fix with_role with :any resource

### DIFF
--- a/lib/rolify/finders.rb
+++ b/lib/rolify/finders.rb
@@ -1,7 +1,7 @@
 module Rolify
   module Finders
     def with_role(role_name, resource = nil)
-      strict = self.strict_rolify and resource and resource != :any
+      strict = self.strict_rolify && resource && resource != :any
       self.adapter.scope(
         self,
         { :name => role_name, :resource => resource },

--- a/spec/rolify/shared_examples/shared_examples_for_finders.rb
+++ b/spec/rolify/shared_examples/shared_examples_for_finders.rb
@@ -63,6 +63,11 @@ shared_examples_for :finders do |param_name, param_method|
             it { subject.with_role("admin".send(param_method), Forum.first).should be_empty }
             it { subject.with_role("moderator".send(param_method), Forum.first).should be_empty }
           end
+
+          context "on any resource" do
+            it { subject.with_role("admin".send(param_method), :any).should_not be_empty }
+            it { subject.with_role("moderator".send(param_method), :any).should_not be_empty }
+          end
         end
       end
     end
@@ -115,7 +120,7 @@ shared_examples_for :finders do |param_name, param_method|
         end
       end
     end
-    
+
 
     describe ".with_all_roles" do
       it { should respond_to(:with_all_roles) }


### PR DESCRIPTION
Pre 6.0.0, this used to work with strict.

```
  User.with_role(:owner, :any)
```

With 6.0.0, (due to the PR https://github.com/RolifyCommunity/rolify/pull/543), the above code breaks.

```
> User.with_role(:owner, :any)
NoMethodError: undefined method `id' for :any:Symbol
from /usr/local/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rolify-6.0.0/lib/rolify/adapters/active_record/role_adapter.rb:17:in `where_strict'
```

This is because of line https://github.com/RolifyCommunity/rolify/blob/e07e69f27a4b5c402c13294699eb8581d17219e7/lib/rolify/finders.rb#L4

In Ruby, `and` keyword and `&&` operator have different orders of precedence.

In the below case, (a = true) is evaluated first.  Hence, `strict` from the aboe line is always true in strict mode.

```
> a = true and false
false
> a
true
```


