### PR TITLE
Support auditing needs by switching to `has_many, through`

### DIFF
--- a/lib/rolify.rb
+++ b/lib/rolify.rb
@@ -24,10 +24,12 @@ module Rolify
     self.role_join_table_name = options[:role_join_table_name]
 
     rolify_options = { :class_name => options[:role_cname].camelize }
-    rolify_options.merge!({ :join_table => self.role_join_table_name }) if Rolify.orm == "active_record"
     rolify_options.merge!(options.reject{ |k,v| ![ :before_add, :after_add, :before_remove, :after_remove, :inverse_of ].include? k.to_sym })
+    join_table_options = { }
+    join_table_options.merge!(options.reject{ |k,v| ![ :as ].include? k.to_sym })
 
-    has_and_belongs_to_many :roles, **rolify_options
+    has_many self.role_join_table_name.to_sym, dependent: :destroy, **join_table_options
+    has_many :roles, through: self.role_join_table_name.to_sym, **rolify_options
 
     self.adapter = Rolify::Adapter::Base.create("role_adapter", self.role_cname, self.name)
 

--- a/lib/rolify.rb
+++ b/lib/rolify.rb
@@ -24,9 +24,7 @@ module Rolify
     self.role_join_table_name = options[:role_join_table_name]
 
     rolify_options = { :class_name => options[:role_cname].camelize }
-    rolify_options.merge!(options.reject{ |k,v| ![ :before_add, :after_add, :before_remove, :after_remove, :inverse_of ].include? k.to_sym })
-    join_table_options = { }
-    join_table_options.merge!(options.reject{ |k,v| ![ :as ].include? k.to_sym })
+    join_table_options = options.select{ |k,v| [ :as, :before_add, :after_add, :before_remove, :after_remove, :inverse_of ].include? k.to_sym }
 
     has_many self.role_join_table_name.to_sym, dependent: :destroy, **join_table_options
     has_many :roles, through: self.role_join_table_name.to_sym, **rolify_options

--- a/lib/rolify/adapters/active_record/role_adapter.rb
+++ b/lib/rolify/adapters/active_record/role_adapter.rb
@@ -61,6 +61,7 @@ module Rolify
         cond[:resource_id] = resource.id if resource && !resource.is_a?(Class)
         roles = relation.roles.where(cond)
         if roles
+          join_table = relation.class.reflect_on_association(:roles).options[:through]
           relation.send(join_table).where(role_id: roles.ids).destroy_all
           roles.each do |role|
             role.destroy if role.send(ActiveSupport::Inflector.demodulize(user_class).tableize.to_sym).limit(1).empty?

--- a/lib/rolify/adapters/active_record/role_adapter.rb
+++ b/lib/rolify/adapters/active_record/role_adapter.rb
@@ -61,7 +61,7 @@ module Rolify
         cond[:resource_id] = resource.id if resource && !resource.is_a?(Class)
         roles = relation.roles.where(cond)
         if roles
-          roles = roles.destroy_all
+          relation.send(join_table).where(role_id: roles.ids).destroy_all
           roles.each do |role|
             role.destroy if role.send(ActiveSupport::Inflector.demodulize(user_class).tableize.to_sym).limit(1).empty?
           end if Rolify.remove_role_if_empty

--- a/lib/rolify/adapters/active_record/role_adapter.rb
+++ b/lib/rolify/adapters/active_record/role_adapter.rb
@@ -61,7 +61,7 @@ module Rolify
         cond[:resource_id] = resource.id if resource && !resource.is_a?(Class)
         roles = relation.roles.where(cond)
         if roles
-          relation.roles.delete(roles)
+          roles = roles.destroy_all
           roles.each do |role|
             role.destroy if role.send(ActiveSupport::Inflector.demodulize(user_class).tableize.to_sym).limit(1).empty?
           end if Rolify.remove_role_if_empty

--- a/lib/rolify/adapters/base.rb
+++ b/lib/rolify/adapters/base.rb
@@ -17,7 +17,7 @@ module Rolify
       def role_table
         role_class.table_name
       end
-      
+
       def self.create(adapter, role_cname, user_cname)
         load "rolify/adapters/#{Rolify.orm}/#{adapter}.rb"
         load "rolify/adapters/#{Rolify.orm}/scopes.rb"


### PR DESCRIPTION
Switch from HABTM to `has_many` and `has_many through:`

This will allow users to add columns like `id` and `created_at` to the intermediate table and use paper_trail to track changes to this table, as well as gems like paranoia to soft-delete those records. All of this is super-important from a security auditing perspective.

Pulled code from a [PR](https://github.com/RolifyCommunity/rolify/pull/571) made about 9 months ago that failed tests and was abandoned. Made further changes based on my own needs to adequately support timestamp columns, soft-delete (paranoia) and paper_trail.

I am deliberately removing the records in the join table using `destroy_all` to trigger proper eventing with timestamps and paper_trail, and then still honoring the options removal of role records no longer in use.