### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/activerecord.yml
+++ b/.github/workflows/activerecord.yml
@@ -22,15 +22,12 @@ jobs:
       ADAPTER: active_record
     steps:
       - uses: actions/checkout@v3
+      - run: sudo apt-get install -y libsqlite3-dev
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: sudo apt-get install -y libsqlite3-dev
-      - run: gem update --system
-      - run: gem install bundler
-      - run: gem --version
-      - run: bundle install
+          bundler-cache: true
       - name: Run Tests
         run: |
           bundle exec rake

--- a/.github/workflows/activerecord.yml
+++ b/.github/workflows/activerecord.yml
@@ -7,8 +7,10 @@ jobs:
     strategy:
       matrix:
         gemfile: [activerecord_4, activerecord_5, activerecord_6]
-        ruby: [2.5.7, 2.6.5, 2.7.2]
+        ruby: [2.5.9, 2.6.10, 2.7.7]
         include:
+          - gemfile: activerecord_7
+            ruby: '3.2'
           - gemfile: activerecord_7
             ruby: '3.1'
           - gemfile: activerecord_7

--- a/.github/workflows/mongoid.yml
+++ b/.github/workflows/mongoid.yml
@@ -18,15 +18,12 @@ jobs:
       ADAPTER: mongoid
     steps:
       - uses: actions/checkout@v3
+      - run: sudo apt-get install -y libsqlite3-dev
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: sudo apt-get install -y libsqlite3-dev
-      - run: gem update --system
-      - run: gem install bundler
-      - run: gem --version
-      - run: bundle install
+          bundler-cache: true
       - name: Run Tests
         run: |
           bundle exec rake

--- a/.github/workflows/mongoid.yml
+++ b/.github/workflows/mongoid.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         gemfile: [mongoid_5]
-        ruby: [2.5.7, 2.6.5, 2.7.2]
+        ruby: [2.5.9, 2.6.10, 2.7.7]
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
       ADAPTER: mongoid


### PR DESCRIPTION
This PR also:

1. Switches to using the `ruby/setup-ruby` action so we don't need to worry about installing a compatible bundler for the Ruby version (Bundler 2.4+ no longer supports Ruby 2.6 and earlier)
2. Updates the patch versions for the 2.5, 2.6, and 2.7 Rubies to use the latest.

It runs green on my fork.